### PR TITLE
refactor: Replace linenoise with rustyline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ optional = true
 version = "0.3.3"
 optional = true
 
-[dependencies.linenoise-rust]
-version = "0.2.0"
+[dependencies.rustyline]
+git = "https://github.com/kkawakam/rustyline"
 optional = true
 
 [dependencies.lazy_static]
@@ -69,6 +69,6 @@ skeptic = "0.4"
 [features]
 default = ["repl"]
 
-repl = ["env_logger", "lazy_static", "linenoise-rust"]
+repl = ["env_logger", "lazy_static", "rustyline"]
 test = ["gluon_vm/test", "gluon_check/test", "gluon_parser/test", "repl"]
 nightly = ["compiletest_rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ extern crate clap;
 extern crate quick_error;
 #[macro_use]
 extern crate lazy_static;
-extern crate linenoise;
 
 extern crate gluon_base as base;
 extern crate gluon;
@@ -57,16 +56,16 @@ fn main() {
             init_env_logger();
 
             let matches = App::new("gluon")
-                              .about("Executes gluon programs")
-                              .arg(Arg::with_name("INPUT")
-                                       .multiple(true)
-                                       .help("Executes each file as a gluon program"))
-                              .arg(Arg::with_name("REPL")
-                                       .short("i")
-                                       .long("interactive")
-                                       .help("Starts the repl")
-                                       .takes_value(false))
-                              .get_matches();
+                .about("Executes gluon programs")
+                .arg(Arg::with_name("INPUT")
+                    .multiple(true)
+                    .help("Executes each file as a gluon program"))
+                .arg(Arg::with_name("REPL")
+                    .short("i")
+                    .long("interactive")
+                    .help("Starts the repl")
+                    .takes_value(false))
+                .get_matches();
             if matches.is_present("REPL") {
                 if let Err(err) = repl::run() {
                     println!("{}", err);

--- a/std/repl.glu
+++ b/std/repl.glu
@@ -81,7 +81,7 @@ let store line: String -> IO Bool =
             io.load_script binding expr >> return True
         | None -> io.print "Expected binding in definition" >> return True
 
-let loop x: () -> IO () =
+let loop editor: Editor -> IO () =
     let run_line line =
         if string.is_empty (string.trim line) then
             return True
@@ -94,14 +94,14 @@ let loop x: () -> IO () =
                 >>= io.print
                 >> return True
 
-    repl_prim.input "> " >>= \line_opt ->
+    rustyline.readline editor "> " >>= \line_opt ->
         match line_opt with
             | None -> return ()
             | Some line -> run_line line >>= \continue ->
-                if continue then loop () else return ()
+                if continue then loop editor else return ()
 
 let run x: () -> IO () =
     io.print "gluon (:h for help, :q to quit)"
-        >>= loop
+        >> loop (rustyline.new_editor ())
 
 run


### PR DESCRIPTION
Rustyline is a pure rust implementation of linenoise with some additional features which will make it possible to add completion to the repl.

The windows support in Rustyline is currently only partial (history support and modifier keys are not yet working). I will likely add in completion support as well before merging.