### PR TITLE
fix(check): Don't bind uninstantiated type signatures to arguments

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -616,7 +616,7 @@ impl<'a> Typecheck<'a> {
                         self.typecheck(&mut bind.expression)
                     } else {
                         let function_type = match bind.typ {
-                            Some(ref typ) => typ.clone(),
+                            Some(ref typ) => self.instantiate(typ),
                             None => self.subs.new_var(),
                         };
                         self.typecheck_lambda(function_type,

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1063,9 +1063,15 @@ impl<'a> Typecheck<'a> {
             String::from(max_var)
         };
         let mut i = 0;
+        self.finish_type_(level, &generic, &mut i, typ)
+    }
+
+    fn finish_type_(&mut self, level: u32, generic: &str, i: &mut i32, typ: TcType) -> TcType {
         types::walk_move_type(typ,
-                              &mut |typ| {
-            let replacement = self.subs.replace_variable(typ);
+                                  &mut |typ| {
+            let replacement = self.subs
+                .replace_variable(typ)
+                .map(|t| self.finish_type_(level, generic, i, t));
             let mut typ = typ;
             if let Some(ref t) = replacement {
                 debug!("{} ==> {}",
@@ -1076,7 +1082,7 @@ impl<'a> Typecheck<'a> {
             match *typ {
                 Type::Variable(ref var) if self.subs.get_level(var.id) > level => {
                     let generic = format!("{}{}", generic, i);
-                    i += 1;
+                    *i += 1;
                     let id = self.symbols.symbol(generic);
                     let gen: TcType = Type::generic(Generic {
                         kind: var.kind.clone(),

--- a/check/tests/typecheck.rs
+++ b/check/tests/typecheck.rs
@@ -802,6 +802,21 @@ else
 }
 
 #[test]
+fn arguments_need_to_be_instantiated_before_any_access() {
+    let _ = ::env_logger::init();
+    // test_fn: forall a. (a -> ()) -> ()
+    // To allow any type to be passed to `f` it should be
+    // test_fn: (forall a. a -> ()) -> ()
+    let text = r#"
+let test_fn f: (a -> ()) -> () =
+    f 2.0
+1
+"#;
+    let result = typecheck(text);
+    assert_unify_err!(result, TypeMismatch(..));
+}
+
+#[test]
 fn module() {
     let _ = ::env_logger::init();
     let text = r"

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -20,7 +20,7 @@ type Monoid m = {
 
 let monoid_Function m: Monoid b -> (Monoid (a -> b)) = {
     (<>) = \f g -> \x -> m.(<>) (f x) (g x),
-    empty = m.empty
+    empty = \_ -> m.empty
 }
 
 let monoid_List =
@@ -473,10 +473,10 @@ let flip f : (a -> b -> c) -> b -> a -> c =
     \x y -> f y x
 
 /// Backward function application, where `f <| x == f x`
-let (<|) f x : a -> (a -> b) -> b = f x
+let (<|) f x : (a -> b) -> a -> b = f x
 
 /// Forward function application, where `x |> f == f x`
-let (|>) x f : (a -> b) -> a -> b = f x
+let (|>) x f : a -> (a -> b) -> b = f x
 
 /// Right-to-left function composition
 let (<<) : (b -> c) -> (a -> b) -> a -> c =

--- a/std/state.glu
+++ b/std/state.glu
@@ -6,14 +6,15 @@ let functor : Functor (State s) =
     let map f m : (a -> b) -> State s a -> State s b =
         \state ->
             let { value, state } = m state
-            { value = f value, state = state  }
+            { value = f value, state = state }
 
     { map }
 
 let applicative : Applicative (State s) =
-    let (<*>) mf state : State s (a -> b) -> State s a -> State s b =
-        let { value, state } = mf state
-        functor.map value state
+    let (<*>) mf n : State s (a -> b) -> State s a -> State s b =
+        \state ->
+            let { value, state } = mf state
+            functor.map value n state
 
     let pure value: a -> State s a =
         \state -> { value, state }
@@ -37,7 +38,7 @@ let gets f: (s -> a) -> State s a = \state -> { value = f state, state }
 
 let modify f: (s -> s) -> State s () = \state -> { value = (), state = f state }
 
-let runState f state: State s a -> s -> { value: a, state: a } = f state
+let runState f state: State s a -> s -> { value: a, state: s } = f state
 
 let evalState f state: State s a -> s -> a = (runState f state).value
 


### PR DESCRIPTION
Without instantiating the type signature all uses of the function arguments would instantiate the argument's type with fresh variables on every use which easily masked the problem by allowing wrongly typed code to pass.