### PR TITLE
Update dependencies and add workspace field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,15 +45,16 @@ path = "vm"
 version = "0.1.2"
 
 [dependencies.compiletest_rs]
-version = "0.1.3"
+version = "0.2"
 optional = true
 
 [dependencies.env_logger]
-version = "0.3.3"
+version = "0.3.4"
 optional = true
 
 [dependencies.rustyline]
 git = "https://github.com/kkawakam/rustyline"
+rev = "480bf15"
 optional = true
 
 [dependencies.lazy_static]
@@ -61,10 +62,10 @@ version = "0.2.0"
 optional = true
 
 [build-dependencies]
-skeptic = "0.4"
+skeptic = "0.6"
 
 [dev-dependencies]
-skeptic = "0.4"
+skeptic = "0.6"
 
 [features]
 default = ["repl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,42 +24,17 @@ name = "repl"
 path = "src/main.rs"
 
 [dependencies]
-log = "0.3.6"
 clap = "2.2.5"
+compiletest_rs = { version = "0.2", optional = true }
+env_logger = { version = "0.3.4", optional = true }
+lazy_static = { version = "0.2.0", optional = true }
+log = "0.3.6"
 quick-error = "1.0.0"
-
-[dependencies.gluon_base]
-path = "base"
-version = "0.1.3"
-
-[dependencies.gluon_parser]
-path = "parser"
-version = "0.1.2"
-
-[dependencies.gluon_check]
-path = "check"
-version = "0.1.3"
-
-[dependencies.gluon_vm]
-path = "vm"
-version = "0.1.2"
-
-[dependencies.compiletest_rs]
-version = "0.2"
-optional = true
-
-[dependencies.env_logger]
-version = "0.3.4"
-optional = true
-
-[dependencies.rustyline]
-git = "https://github.com/kkawakam/rustyline"
-rev = "480bf15"
-optional = true
-
-[dependencies.lazy_static]
-version = "0.2.0"
-optional = true
+rustyline = { git = "https://github.com/kkawakam/rustyline", rev = "480bf15", optional = true }
+gluon_base = { path = "base", version = "0.1.3" }
+gluon_check = { path = "check", version = "0.1.3" }
+gluon_parser = { path = "parser", version = "0.1.2" }
+gluon_vm = { path = "vm", version = "0.1.2" }
 
 [build-dependencies]
 skeptic = "0.6"

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -6,12 +6,9 @@ authors = ["Markus Westerlind <marwes91@gmail.com>"]
 [lib]
 crate-type = ["staticlib"]
 
-[dependencies.gluon]
-version = "0.1.3"
-path = ".."
-
-[dependencies.libc]
-version = "0.2.14"
+[dependencies]
+libc = "0.2.14"
+gluon = { version = "0.1.3", path = ".." }
 
 [features]
 test = ["gluon/test"]

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.3"
 path = ".."
 
 [dependencies.libc]
-version = "0.2.0"
+version = "0.2.14"
 
 [features]
 test = ["gluon/test"]

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.1.2"
 optional = true
 
 [dependencies.env_logger]
-version = "0.3.3"
+version = "0.3.4"
 optional = true
 
 [features]

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -11,21 +11,11 @@ repository = "https://github.com/Marwes/gluon"
 documentation = "https://marwes.github.io/gluon/gluon/index.html"
 
 [dependencies]
+env_logger = { version = "0.3.4", optional = true }
 log = "0.3.6"
 union-find = "0.3.1"
-
-[dependencies.gluon_base]
-path = "../base"
-version = "0.1.3"
-
-[dependencies.gluon_parser]
-path = "../parser"
-version = "0.1.2"
-optional = true
-
-[dependencies.env_logger]
-version = "0.3.4"
-optional = true
+gluon_base = { path = "../base", version = "0.1.3" }
+gluon_parser = { path = "../parser", version = "0.1.2", optional = true }
 
 [features]
 test = ["gluon_parser", "env_logger"]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -24,7 +24,7 @@ path = "../base"
 version = "0.1.2"
 
 [dependencies.env_logger]
-version = "0.3.3"
+version = "0.3.4"
 optional = true
 
 [features]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -11,21 +11,11 @@ repository = "https://github.com/Marwes/gluon"
 documentation = "https://marwes.github.io/gluon/gluon/index.html"
 
 [dependencies]
+combine-language = "=2.0.0-beta"
+combine = "=2.0.0-beta"
+env_logger = { version = "0.3.4", optional = true }
 log = "0.3.6"
-
-[dependencies.combine-language]
-version = "=2.0.0-beta"
-
-[dependencies.combine]
-version = "=2.0.0-beta"
-
-[dependencies.gluon_base]
-path = "../base"
-version = "0.1.2"
-
-[dependencies.env_logger]
-version = "0.3.4"
-optional = true
+gluon_base = { path = "../base", version = "0.1.2" }
 
 [features]
 test = ["env_logger"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -11,17 +11,11 @@ repository = "https://github.com/Marwes/gluon"
 documentation = "https://marwes.github.io/gluon/gluon/index.html"
 
 [dependencies]
+env_logger = { version = "0.3.4", optional = true }
 log = "0.3.6"
 quick-error = "1.1.0"
 mopa = "0.2.2"
-
-[dependencies.gluon_base]
-path = "../base"
-version = "0.1.2"
-
-[dependencies.env_logger]
-version = "0.3.4"
-optional = true
+gluon_base = { path = "../base", version = "0.1.2" }
 
 [features]
 test = ["env_logger"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://marwes.github.io/gluon/gluon/index.html"
 
 [dependencies]
 log = "0.3.6"
-quick-error = "1.0.0"
+quick-error = "1.1.0"
 mopa = "0.2.2"
 
 [dependencies.gluon_base]
@@ -20,7 +20,7 @@ path = "../base"
 version = "0.1.2"
 
 [dependencies.env_logger]
-version = "0.3.3"
+version = "0.3.4"
 optional = true
 
 [features]


### PR DESCRIPTION
I find the map version of specifying dependencies easier to scan and update. Not sure if you agree!

I've also added a workspace so that if you do a build in a sub-directory it will reuse the root target directory.

Rustyline has been pegged to a specific git revision so as to ensure repeatable builds.