### PR TITLE
chore: Remove travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_script:
   export PATH=$HOME/.local/bin:$PATH
 script:
 - |
-  travis_wait 40 sh ./test.sh &&
+  sh ./test.sh &&
   travis-cargo --only nightly test -- --features "test nightly" -p gluon compile_test &&
-  travis_wait 40 cargo build --release &&
+  cargo build --release &&
   travis-cargo --only nightly bench &&
   travis-cargo --only stable doc
 after_success:


### PR DESCRIPTION
This is just a hunch but it might be that travis_wait messes up something when it writes to stdout which causes skeptic to fail