### PR TITLE
Refactor parts of the check crate

### DIFF
--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -1,4 +1,5 @@
 //! Module containing types representing `gluon`'s type system
+use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
@@ -923,20 +924,20 @@ pub fn walk_move_type<F, I, T>(typ: T, f: &mut F) -> T
 
 /// Merges two values using `f` if either or both them is `Some(..)`.
 /// If both are `None`, `None` is returned.
-pub fn merge<F, A, B, R>(a_original: &A,
-                         a: Option<A>,
-                         b_original: &B,
-                         b: Option<B>,
-                         f: F)
-                         -> Option<R>
-    where A: Clone,
-          B: Clone,
-          F: FnOnce(A, B) -> R
+pub fn merge<F, A: ?Sized, B: ?Sized, R>(a_original: &A,
+                                         a: Option<A::Owned>,
+                                         b_original: &B,
+                                         b: Option<B::Owned>,
+                                         f: F)
+                                         -> Option<R>
+    where A: ToOwned,
+          B: ToOwned,
+          F: FnOnce(A::Owned, B::Owned) -> R
 {
     match (a, b) {
         (Some(a), Some(b)) => Some(f(a, b)),
-        (Some(a), None) => Some(f(a, b_original.clone())),
-        (None, Some(b)) => Some(f(a_original.clone(), b)),
+        (Some(a), None) => Some(f(a, b_original.to_owned())),
+        (None, Some(b)) => Some(f(a_original.to_owned(), b)),
         (None, None) => None,
     }
 }

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -146,12 +146,8 @@ impl<'a> KindCheck<'a> {
 
     fn builtin_kind(&self, typ: BuiltinType) -> RcKind {
         match typ {
-            BuiltinType::String |
-            BuiltinType::Byte |
-            BuiltinType::Char |
-            BuiltinType::Int |
-            BuiltinType::Float |
-            BuiltinType::Unit => self.type_kind(),
+            BuiltinType::String | BuiltinType::Byte | BuiltinType::Char | BuiltinType::Int |
+            BuiltinType::Float | BuiltinType::Unit => self.type_kind(),
             BuiltinType::Array => self.function1_kind(),
             BuiltinType::Function => self.function2_kind(),
         }

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -115,7 +115,7 @@ impl<'a> KindCheck<'a> {
             })
             .or_else(|| self.info.find_kind(id))
             .map_or_else(|| {
-                let id_str = self.idents.string(&id);
+                let id_str = self.idents.string(id);
                 if id_str.chars().next().map_or(false, |c| c.is_uppercase()) {
                     Err(UnifyError::Other(KindError::UndefinedType(id.clone())))
                 } else {

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -165,13 +165,13 @@ pub fn rename(symbols: &mut SymbolModule,
             let locals = self.env
                 .stack
                 .get_all(id);
-            let global = self.env.env.find_type(&id).map(|typ| (id, None, typ));
+            let global = self.env.env.find_type(id).map(|typ| (id, None, typ));
             let candidates = || {
                 locals.iter()
                     .flat_map(|bindings| {
                         bindings.iter().rev().map(|bind| (&bind.0, Some(&bind.1), &bind.2))
                     })
-                    .chain(global.clone())
+                    .chain(global)
             };
             // If there is a single binding (or no binding in case of primitives such as #Int+)
             // there is no need to check for equivalency as typechecker couldnt have infered a

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -90,10 +90,9 @@ impl<I: fmt::Display + AsRef<str>> fmt::Display for TypeError<I> {
                     return Ok(());
                 }
                 for error in &errors[..errors.len() - 1] {
-                    try!(::unify_type::fmt_error(error, f));
-                    try!(writeln!(f, ""));
+                    try!(writeln!(f, "{}", error));
                 }
-                ::unify_type::fmt_error(errors.last().unwrap(), f)
+                write!(f, "{}", errors.last().unwrap())
             }
             PatternError(ref typ, expected_len) => {
                 write!(f, "Type {} has {} to few arguments", typ, expected_len)

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -540,11 +540,11 @@ impl<'a> Typecheck<'a> {
                             op.typ = try!(self.find(op.id()));
                             let func_type = Type::function(vec![lhs_type, rhs_type],
                                                            self.subs.new_var());
-                            let ret =
-                                try!(self.unify(&op.typ, func_type)).as_function()
-                                    .and_then(|(_, ret)| ret.as_function())
-                                    .map(|(_, ret)| ret.clone())
-                                    .expect("ICE: unify binop");
+                            let ret = try!(self.unify(&op.typ, func_type))
+                                .as_function()
+                                .and_then(|(_, ret)| ret.as_function())
+                                .map(|(_, ret)| ret.clone())
+                                .expect("ICE: unify binop");
 
                             Ok(ret)
                         }
@@ -978,9 +978,7 @@ impl<'a> Typecheck<'a> {
                 self.stack_var(args[0].id().clone(), arg.clone());
                 self.typecheck_pattern_rec(&args[1..], ret.clone())
             }
-            None => {
-                Err(PatternError(typ.clone(), args.len()))
-            },
+            None => Err(PatternError(typ.clone(), args.len())),
         }
     }
 
@@ -1367,4 +1365,3 @@ pub fn unroll_app(typ: &Type<Symbol>) -> Option<TcType> {
         Some(Type::app(current.clone(), args))
     }
 }
-

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::hash::Hash;
 
 use base::error::Errors;
@@ -11,6 +12,24 @@ pub enum Error<T: Substitutable, E> {
     Occurs(T::Variable, T),
     Other(E),
 }
+
+impl<T, E> fmt::Display for Error<T, E>
+    where T: Substitutable + fmt::Display,
+          T::Variable: fmt::Display,
+          E: fmt::Display
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use unify::Error::*;
+        match *self {
+            TypeMismatch(ref l, ref r) => {
+                write!(f, "Types do not match:\n\tExpected: {}\n\tFound: {}", l, r)
+            }
+            Occurs(ref var, ref typ) => write!(f, "Variable `{}` occurs in `{}`.", var, typ),
+            Other(ref err) => write!(f, "{}", err),
+        }
+    }
+}
+
 
 pub struct UnifierState<'s, S: ?Sized + 's, T: 's, U> {
     pub state: &'s mut S,

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -149,13 +149,30 @@ fn do_zip_match<'a, 's, U>(self_: &TcType,
     debug!("Unifying:\n{:?} <=> {:?}", self_, other);
     match (&**self_, &**other) {
         (&Type::App(ref l, ref l_args), &Type::App(ref r, ref r_args)) => {
-            if l_args.len() == r_args.len() {
-                let ctor = unifier.try_match(l, r);
-                let args = walk_move_types(l_args.iter().zip(r_args.iter()),
-                                           |l, r| unifier.try_match(l, r));
-                Ok(merge(l, ctor, l_args, args, Type::app))
-            } else {
-                unify_app(unifier, l, l_args, other)
+            use std::cmp::Ordering::*;
+            match l_args.len().cmp(&r_args.len()) {
+                Equal => {
+                    let new_type = unifier.try_match(l, r);
+                    let new_args = walk_move_types(l_args.iter().zip(r_args),
+                                                   |l, r| unifier.try_match(l, r));
+                    Ok(merge(l, new_type, l_args, new_args, Type::app))
+                }
+                Less => {
+                    let offset = r_args.len() - l_args.len();
+                    let new_type =
+                        unifier.try_match(l, &Type::app(r.clone(), r_args[..offset].into()));
+                    let new_args = walk_move_types(l_args.iter().zip(&r_args[offset..]),
+                                                   |l, r| unifier.try_match(l, r));
+                    Ok(merge(l, new_type, l_args, new_args, Type::app))
+                }
+                Greater => {
+                    let offset = l_args.len() - r_args.len();
+                    let new_type =
+                        unifier.try_match(&Type::app(l.clone(), l_args[..offset].into()), r);
+                    let new_args = walk_move_types(l_args[offset..].iter().zip(r_args),
+                                                   |l, r| unifier.try_match(l, r));
+                    Ok(merge(r, new_type, r_args, new_args, Type::app))
+                }
             }
         }
         (&Type::Record { fields: ref l_args, types: ref l_types },
@@ -327,77 +344,6 @@ fn try_with_alias<'a, 's, U>(unifier: &mut UnifierState<'a, 's, U>,
             unifier.try_match(l, r);
             Ok(None)
         }
-    }
-}
-
-fn unify_app<'a, 's, U, E>(unifier: &mut UnifierState<'a, 's, U>,
-                           l: &TcType,
-                           l_args: &[TcType],
-                           r: &TcType)
-                           -> Result<Option<TcType>, E>
-    where U: Unifier<State<'a>, TcType>
-{
-    let mut args = Vec::new();
-    unify_app_(unifier, l, l_args, r, false, &mut args);
-    if args.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(Type::app(l.clone(), args)))
-    }
-}
-
-fn unify_app_<'a, 's, U>(unifier: &mut UnifierState<'a, 's, U>,
-                         l: &TcType,
-                         l_args: &[TcType],
-                         r: &TcType,
-                         replaced: bool,
-                         output: &mut Vec<TcType>)
-    where U: Unifier<State<'a>, TcType>
-{
-    let r = unifier.subs.real(r);
-    let new = match **r {
-        Type::App(ref r, ref r_args) => {
-            use std::cmp::Ordering::*;
-            let args_iter = match l_args.len().cmp(&r_args.len()) {
-                Equal => {
-                    unifier.try_match(l, r);
-                    l_args.iter().zip(r_args)
-                }
-                Less => {
-                    let offset = r_args.len() - l_args.len();
-                    unifier.try_match(l, &Type::app(r.clone(), r_args[..offset].into()));
-                    l_args.iter().zip(&r_args[offset..])
-                }
-                Greater => {
-                    let offset = l_args.len() - r_args.len();
-                    unifier.try_match(&Type::app(l.clone(), l_args[..offset].into()), r);
-                    r_args.iter().zip(&l_args[offset..])
-                }
-            };
-            // Unify the last min(l_args.len(), r_args.len()) arguments
-            match walk_move_types(args_iter, |l, r| unifier.try_match(l, r)) {
-                Some(args) => {
-                    output.extend(args);
-                    return;
-                }
-                None => None,
-            }
-        }
-        _ => {
-            let l = Type::app(l.clone(), l_args.iter().cloned().collect());
-            unifier.try_match(&l, r);
-            // Dont push the actual type that is applied
-            return;
-        }
-    };
-    match new {
-        Some(typ) => {
-            output.push(typ);
-        }
-        None if replaced || !output.is_empty() => {
-            output.push(r.clone());
-        }
-        None => (),
     }
 }
 

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -58,7 +58,9 @@ impl<I> fmt::Display for TypeError<I>
             }
             TypeError::UndefinedType(ref id) => write!(f, "Type `{}` does not exist.", id),
             TypeError::SelfRecursive(ref id) => {
-                write!(f, "The use of self recursion in type `{}` could not be unified.", id)
+                write!(f,
+                       "The use of self recursion in type `{}` could not be unified.",
+                       id)
             }
         }
     }

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -45,30 +45,24 @@ impl From<instantiate::Error> for Error<Symbol> {
     }
 }
 
-pub fn fmt_error<I>(error: &Error<I>, f: &mut fmt::Formatter) -> fmt::Result
+impl<I> fmt::Display for TypeError<I>
     where I: fmt::Display + AsRef<str>
 {
-    use unify::Error::*;
-    match *error {
-        TypeMismatch(ref l, ref r) => {
-            write!(f, "Types do not match:\n\tExpected: {}\n\tFound: {}", l, r)
-        }
-        Other(TypeError::FieldMismatch(ref l, ref r)) => {
-            write!(f,
-                   "Field names in record do not match.\n\tExpected: {}\n\tFound: {}",
-                   l,
-                   r)
-        }
-        Occurs(ref var, ref typ) => write!(f, "Variable `{}` occurs in `{}`.", var, typ),
-        Other(TypeError::UndefinedType(ref id)) => write!(f, "Type `{}` does not exist.", id),
-        Other(TypeError::SelfRecursive(ref id)) => {
-            write!(f,
-                   "The use of self recursion in type `{}` could not be unified.",
-                   id)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TypeError::FieldMismatch(ref l, ref r) => {
+                write!(f,
+                       "Field names in record do not match.\n\tExpected: {}\n\tFound: {}",
+                       l,
+                       r)
+            }
+            TypeError::UndefinedType(ref id) => write!(f, "Type `{}` does not exist.", id),
+            TypeError::SelfRecursive(ref id) => {
+                write!(f, "The use of self recursion in type `{}` could not be unified.", id)
+            }
         }
     }
 }
-
 
 pub type UnifierState<'a, 's, U> = unify::UnifierState<'s, State<'a>, TcType, U>;
 


### PR DESCRIPTION
Simplifies a few parts of the unification and runs clippy on the check crate. Wanted to use quick-error on the error types as well but unfortunately quick-error does not support parameterized errors.