### PR TITLE
read GLUON_PATH from env var and add to new_vm

### DIFF
--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -57,6 +57,15 @@ impl MacroEnv {
         self.macros.write().unwrap().insert(name, Box::new(mac));
     }
 
+    /// Inserts a `Macro` then returns an instance of Option<Box<Macro>> using self.get
+    pub fn insert_and_get<M>(&self, name: String, mac: M) -> Option<Box<Macro>>
+        where M: Macro + 'static
+    {
+        let get_name = name.clone();
+        self.insert(name, mac);
+        self.get(&get_name)
+    }
+
     /// Retrieves the macro bound to `symbol`
     pub fn get(&self, name: &str) -> Option<Box<Macro>> {
         self.macros.read().unwrap().get(name).map(|x| (**x).clone())

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -57,15 +57,6 @@ impl MacroEnv {
         self.macros.write().unwrap().insert(name, Box::new(mac));
     }
 
-    /// Inserts a `Macro` then returns an instance of Option<Box<Macro>> using self.get
-    pub fn insert_and_get<M>(&self, name: String, mac: M) -> Option<Box<Macro>>
-        where M: Macro + 'static
-    {
-        let get_name = name.clone();
-        self.insert(name, mac);
-        self.get(&get_name)
-    }
-
     /// Retrieves the macro bound to `symbol`
     pub fn get(&self, name: &str) -> Option<Box<Macro>> {
         self.macros.read().unwrap().get(name).map(|x| (**x).clone())


### PR DESCRIPTION
@brendanzab 
I tried to do this as was said in the issue. I've exported a GLUON_PATH variable and it appears to get read while the vm is created. 

Feel free to completely reject this code if it's not up to snuff, as I said before I'm just a beginner with Rust.

In the interest of adding the path without any explicit conditionals, I added a method `insert_and_get` to `vm/src/macros` so that the function calls could be chained. If no path is found, it should just grab the current directory. 

Rebased off of master just prior.