### PR TITLE
Fix a few error cases when using `:i`, `:k` and `:t` from the repl

### DIFF
--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -808,7 +808,7 @@ impl<'a, I, T, E> fmt::Display for DisplayType<'a, I, T, E>
                         None => try!(write!(f, "= <abstract>")),
                     }
                     for field in &types[1..] {
-                        try!(write!(f, " {} ", self.env.string(&field.name)));
+                        try!(write!(f, ", {} ", self.env.string(&field.name)));
                         for arg in &field.typ.args {
                             try!(write!(f, "{} ", self.env.string(&arg.id)));
                         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -16,7 +16,7 @@ use gluon::{Compiler, new_vm};
 
 fn type_of_expr(args: WithVM<RootStr>) -> IO<Result<String, String>> {
     let WithVM { vm, value: args } = args;
-    let mut compiler = Compiler::new().implicit_prelude(false);
+    let mut compiler = Compiler::new();
     IO::Value(match compiler.typecheck_str(vm, "<repl>", &args, None) {
         Ok((expr, _)) => {
             let env = vm.get_env();

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -369,7 +369,7 @@ impl<'vm> Getable<'vm> for u8 {
 }
 
 impl VMType for i32 {
-    type Type = Self;
+    type Type = VMInt;
 }
 impl<'vm> Pushable<'vm> for i32 {
     fn push(self, _: &'vm Thread, stack: &mut Stack) -> Status {
@@ -386,7 +386,7 @@ impl<'vm> Getable<'vm> for i32 {
     }
 }
 impl VMType for u32 {
-    type Type = Self;
+    type Type = VMInt;
 }
 impl<'vm> Pushable<'vm> for u32 {
     fn push(self, _: &'vm Thread, stack: &mut Stack) -> Status {


### PR DESCRIPTION
Re-submitted PR of #73 since I apparently closed that instead of merging