### PR TITLE
feat(check): Generate generic variable names less naively

### DIFF
--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -866,37 +866,37 @@ impl<I, T> fmt::Display for Type<I, T>
     }
 }
 
-pub fn walk_type<'t, I: 't, T, F>(typ: &'t T, mut f: F)
-    where F: FnMut(&'t T) -> &'t T,
+pub fn walk_type<I, T, F>(typ: &T, mut f: F)
+    where F: FnMut(&T),
           T: Deref<Target = Type<I, T>>
 {
-    walk_type_(typ, &mut f)
+    f.walk(typ)
 }
 
-fn walk_type_<'t, I: 't, T, F>(typ: &'t T, f: &mut F)
-    where F: FnMut(&'t T) -> &'t T,
+pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
+    where F: Walker<T>,
           T: Deref<Target = Type<I, T>>
 {
-    let typ = f(typ);
     match **typ {
-        Type::App(_, ref args) => {
+        Type::App(ref t, ref args) => {
+            f.walk(t);
             for a in args {
-                walk_type_(a, f);
+                f.walk(a);
             }
         }
         Type::Record { ref types, ref fields } => {
             for field in types {
                 if let Some(ref typ) = field.typ.typ {
-                    walk_type_(typ, f);
+                    f.walk(typ);
                 }
             }
             for field in fields {
-                walk_type_(&field.typ, f);
+                f.walk(&field.typ);
             }
         }
         Type::Variants(ref variants) => {
             for variant in variants {
-                walk_type_(&variant.1, f);
+                f.walk(&variant.1);
             }
         }
         Type::Builtin(_) |
@@ -912,21 +912,78 @@ pub fn fold_type<I, T, F, A>(typ: &T, mut f: F, a: A) -> A
           T: Deref<Target = Type<I, T>>
 {
     let mut a = Some(a);
-    walk_type(typ,
-              &mut |t| {
-                  a = Some(f(t, a.take().expect("None in fold_type")));
-                  t
-              });
+    walk_type(typ, |t| {
+        a = Some(f(t, a.take().expect("None in fold_type")));
+    });
     a.expect("fold_type")
 }
 
+pub fn walk_kind<F: ?Sized>(k: &RcKind, f: &mut F)
+    where F: Walker<RcKind>
+{
+    match **k {
+        Kind::Function(ref a, ref r) => {
+            f.walk(a);
+            f.walk(r);
+        }
+        Kind::Variable(_) |
+        Kind::Type => (),
+    }
+}
+
+
+pub trait TypeVisitor<I, T> {
+    fn visit(&mut self, typ: &Type<I, T>) -> Option<T>
+        where T: Deref<Target = Type<I, T>> + From<Type<I, T>> + Clone,
+              I: Clone
+    {
+        walk_move_type_opt(typ, self)
+    }
+}
+
+pub trait Walker<T> {
+    fn walk(&mut self, typ: &T);
+}
+
+impl<I, T, F: ?Sized> TypeVisitor<I, T> for F
+    where F: FnMut(&Type<I, T>) -> Option<T>
+{
+    fn visit(&mut self, typ: &Type<I, T>) -> Option<T>
+        where T: Deref<Target = Type<I, T>> + From<Type<I, T>> + Clone,
+              I: Clone
+    {
+        let new_type = walk_move_type_opt(typ, self);
+        let new_type2 = self(new_type.as_ref().map_or(typ, |t| t));
+        new_type2.or(new_type)
+    }
+}
+
+impl<I, T, F: ?Sized> Walker<T> for F
+    where F: FnMut(&T),
+          T: Deref<Target = Type<I, T>>
+{
+    fn walk(&mut self, typ: &T) {
+        self(typ);
+        walk_type_(typ, self)
+    }
+}
+
+impl<F: ?Sized> Walker<RcKind> for F
+    where F: FnMut(&RcKind)
+{
+    fn walk(&mut self, typ: &RcKind) {
+        self(typ);
+        walk_kind(typ, self)
+    }
+}
+
 /// Walks through a type calling `f` on each inner type. If `f` return `Some` the type is replaced.
-pub fn walk_move_type<F, I, T>(typ: T, f: &mut F) -> T
+pub fn walk_move_type<F: ?Sized, I, T>(typ: T, f: &mut F) -> T
     where F: FnMut(&Type<I, T>) -> Option<T>,
           T: Deref<Target = Type<I, T>> + From<Type<I, T>> + Clone,
           I: Clone
 {
-    walk_move_type_opt(&typ, f).unwrap_or(typ)
+    f.visit(&typ).unwrap_or(typ)
 }
 
 /// Merges two values using `f` if either or both them is `Some(..)`.
@@ -949,20 +1006,20 @@ pub fn merge<F, A: ?Sized, B: ?Sized, R>(a_original: &A,
     }
 }
 
-pub fn walk_move_type_opt<F, I, T>(typ: &Type<I, T>, f: &mut F) -> Option<T>
-    where F: FnMut(&Type<I, T>) -> Option<T>,
+pub fn walk_move_type_opt<F: ?Sized, I, T>(typ: &Type<I, T>, f: &mut F) -> Option<T>
+    where F: TypeVisitor<I, T>,
           T: Deref<Target = Type<I, T>> + From<Type<I, T>> + Clone,
           I: Clone
 {
-    let new_type = match *typ {
+    match *typ {
         Type::App(ref id, ref args) => {
-            let new_args = walk_move_types(args.iter(), |t| walk_move_type_opt(t, f));
-            merge(id, walk_move_type_opt(id, f), args, new_args, Type::app)
+            let new_args = walk_move_types(args.iter(), |t| f.visit(t));
+            merge(id, f.visit(id), args, new_args, Type::app)
         }
         Type::Record { ref types, ref fields } => {
             let new_types = None;
             let new_fields = walk_move_types(fields.iter(), |field| {
-                walk_move_type_opt(&field.typ, f).map(|typ| {
+                f.visit(&field.typ).map(|typ| {
                     Field {
                         name: field.name.clone(),
                         typ: typ,
@@ -978,19 +1035,15 @@ pub fn walk_move_type_opt<F, I, T>(typ: &Type<I, T>, f: &mut F) -> Option<T>
                 .map(From::from)
         }
         Type::Variants(ref variants) => {
-            walk_move_types(variants.iter(),
-                            |v| walk_move_type_opt(&v.1, f).map(|t| (v.0.clone(), t)))
-                .map(Type::Variants)
-                .map(From::from)
+            walk_move_types(variants.iter(), |v| f.visit(&v.1).map(|t| (v.0.clone(), t)))
+                .map(Type::variants)
         }
         Type::Builtin(_) |
         Type::Variable(_) |
         Type::Generic(_) |
         Type::Id(_) |
         Type::Alias(_) => None,
-    };
-    let new_type2 = f(new_type.as_ref().map_or(typ, |t| t));
-    new_type2.or(new_type)
+    }
 }
 
 fn walk_move_types<'a, I, F, T>(types: I, mut f: F) -> Option<Vec<T>>

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -48,13 +48,10 @@ fn walk_move_kind2<F>(kind: &RcKind, f: &mut F) -> Option<RcKind>
     let new2 = {
         let kind = new.as_ref().unwrap_or(kind);
         match **kind {
-            Kind::Function(ref a, ref r) => {
-                match (walk_move_kind2(a, f), walk_move_kind2(r, f)) {
-                    (Some(a), Some(r)) => Some(Kind::function(a, r)),
-                    (Some(a), None) => Some(Kind::function(a, r.clone())),
-                    (None, Some(r)) => Some(Kind::function(a.clone(), r)),
-                    (None, None) => None,
-                }
+            Kind::Function(ref arg, ref ret) => {
+                let arg_new = walk_move_kind2(arg, f);
+                let ret_new = walk_move_kind2(ret, f);
+                merge(arg, arg_new, ret, ret_new, Kind::function)
             }
             Kind::Type |
             Kind::Variable(_) => None,
@@ -69,6 +66,7 @@ impl<'a> KindCheck<'a> {
                subs: Substitution<RcKind>)
                -> KindCheck<'a> {
         let typ = Kind::typ();
+        let function1_kind = Kind::function(typ.clone(), typ.clone());
         KindCheck {
             variables: Vec::new(),
             locals: Vec::new(),
@@ -76,8 +74,8 @@ impl<'a> KindCheck<'a> {
             idents: idents,
             subs: subs,
             type_kind: typ.clone(),
-            function1_kind: Kind::function(typ.clone(), typ.clone()),
-            function2_kind: Kind::function(typ.clone(), Kind::function(typ.clone(), typ)),
+            function1_kind: function1_kind.clone(),
+            function2_kind: Kind::function(typ, function1_kind),
         }
     }
 

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -1,12 +1,10 @@
 use std::fmt;
 
 use base::ast;
-use base::types;
-use base::types::{Generic, RcKind, Type, Kind, merge};
+use base::types::{self, BuiltinType, Generic, RcKind, TcType, Type, Kind, merge};
 use base::symbol::Symbol;
-use base::types::KindEnv;
+use base::types::{KindEnv, Walker};
 
-use base::types::{BuiltinType, TcType};
 use substitution::{Substitution, Substitutable};
 use unify;
 
@@ -304,21 +302,10 @@ impl Substitutable for RcKind {
         }
     }
 
-    fn traverse<'s, F>(&'s self, mut f: F)
-        where F: FnMut(&'s RcKind) -> &'s RcKind
+    fn traverse<F>(&self, f: &mut F)
+        where F: Walker<RcKind>
     {
-        fn walk_kind<'s>(k: &'s RcKind, f: &mut FnMut(&'s RcKind) -> &'s RcKind) {
-            let k = f(k);
-            match **k {
-                Kind::Function(ref a, ref r) => {
-                    walk_kind(a, f);
-                    walk_kind(r, f);
-                }
-                Kind::Variable(_) |
-                Kind::Type => (),
-            }
-        }
-        walk_kind(self, &mut f)
+        types::walk_kind(self, f);
     }
 }
 

--- a/check/src/substitution.rs
+++ b/check/src/substitution.rs
@@ -6,7 +6,7 @@ use union_find::{QuickFindUf, Union, UnionByRank, UnionFind, UnionResult};
 
 use base::fixed::{FixedMap, FixedVec};
 use base::types;
-use base::types::{TcType, Type};
+use base::types::{TcType, Type, Walker};
 use base::symbol::Symbol;
 
 use typecheck::unroll_app;
@@ -52,28 +52,43 @@ pub trait Substitutable: Sized {
     }
     /// Retrieves the variable if `self` is a variable otherwise returns `None`
     fn get_var(&self) -> Option<&Self::Variable>;
-    fn traverse<'s, F>(&'s self, f: F) where F: FnMut(&'s Self) -> &'s Self;
+    fn traverse<F>(&self, f: &mut F) where F: Walker<Self>;
 }
 
 fn occurs<T>(typ: &T, subs: &Substitution<T>, var: &T::Variable) -> bool
     where T: Substitutable
 {
-    let mut occurs = false;
-    typ.traverse(|typ| {
-        if occurs {
-            return typ;
-        }
-        let typ = subs.real(typ);
-        if let Some(other) = typ.get_var() {
-            if var.get_id() == other.get_id() {
-                occurs = true;
-                return typ;
+    struct Occurs<'a, T: Substitutable + 'a> {
+        occurs: bool,
+        var: &'a T::Variable,
+        subs: &'a Substitution<T>,
+    }
+    impl<'a, T> Walker<T> for Occurs<'a, T>
+        where T: Substitutable
+    {
+        fn walk(&mut self, typ: &T) {
+            if self.occurs {
+                return;
             }
-            subs.update_level(var.get_id(), other.get_id());
+            let typ = self.subs.real(typ);
+            if let Some(other) = typ.get_var() {
+                if self.var.get_id() == other.get_id() {
+                    self.occurs = true;
+                    typ.traverse(self);
+                    return;
+                }
+                self.subs.update_level(self.var.get_id(), other.get_id());
+            }
+            typ.traverse(self);
         }
-        typ
-    });
-    occurs
+    }
+    let mut occurs = Occurs {
+        occurs: false,
+        var: var,
+        subs: subs,
+    };
+    occurs.walk(typ);
+    occurs.occurs
 }
 
 /// Specialized union implementation which makes sure that variables with a higher level always

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1115,7 +1115,6 @@ impl<'a> Typecheck<'a> {
                     self.type_variables.insert(generic.id.clone(), level);
                 }
             }
-            typ
         });
     }
 

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1079,15 +1079,14 @@ impl<'a> Typecheck<'a> {
 
     /// Finish a type by replacing all unbound type variables above `level` with generics
     fn finish_type(&mut self, level: u32, typ: &TcType) -> Option<TcType> {
-        let mut generic = String::new();
-        self.next_variable(level, &mut generic);
+        let mut generic = None;
         let mut i = 0;
-        self.finish_type_(level, &generic, &mut i, typ)
+        self.finish_type_(level, &mut generic, &mut i, typ)
     }
 
     fn finish_type_(&mut self,
                     level: u32,
-                    generic: &str,
+                    generic: &mut Option<String>,
                     i: &mut i32,
                     typ: &Type<Symbol>)
                     -> Option<TcType> {
@@ -1106,6 +1105,14 @@ impl<'a> Typecheck<'a> {
             }
             match *typ {
                 Type::Variable(ref var) if self.subs.get_level(var.id) > level => {
+                    // Create a prefix if none exists
+                    if generic.is_none() {
+                        let mut g = String::new();
+                        self.next_variable(level, &mut g);
+                        *generic = Some(g);
+                    }
+                    let generic = generic.as_ref().unwrap();
+
                     let generic = format!("{}{}", generic, i);
                     *i += 1;
                     let id = self.symbols.symbol(generic);

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -48,13 +48,6 @@ impl<'s, S: ?Sized, Type, U> UnifierState<'s, S, Type, U>
     pub fn try_match(&mut self, l: &Type, r: &Type) -> Option<Type> {
         Unifier::try_match(self, l, r)
     }
-
-    pub fn match_either<F, G>(&mut self, f: F, g: G) -> Result<Option<Type>, ()>
-        where F: FnMut(&mut UnifierState<S, Type, U>) -> Result<Option<Type>, ()>,
-              G: FnMut(&mut UnifierState<S, Type, U>) -> Result<Option<Type>, ()>
-    {
-        Unifier::match_either(self, f, g)
-    }
 }
 
 pub trait Unifier<S: ?Sized, Type>: Sized
@@ -62,18 +55,6 @@ pub trait Unifier<S: ?Sized, Type>: Sized
 {
     fn report_error(unifier: &mut UnifierState<S, Type, Self>, error: Error<Type, Type::Error>);
     fn try_match(unifier: &mut UnifierState<S, Type, Self>, l: &Type, r: &Type) -> Option<Type>;
-    fn match_either<F, G>(unifier: &mut UnifierState<S, Type, Self>,
-                          mut f: F,
-                          mut g: G)
-                          -> Result<Option<Type>, ()>
-        where F: FnMut(&mut UnifierState<S, Type, Self>) -> Result<Option<Type>, ()>,
-              G: FnMut(&mut UnifierState<S, Type, Self>) -> Result<Option<Type>, ()>
-    {
-        match f(unifier) {
-            Ok(typ) => Ok(typ),
-            Err(()) => g(unifier),
-        }
-    }
 }
 
 pub trait Unifiable<S: ?Sized>: Substitutable + Sized {
@@ -123,42 +104,6 @@ impl<'e, S, T> Unifier<S, T> for Unify<'e, T, T::Error>
 {
     fn report_error(unifier: &mut UnifierState<S, T, Self>, error: Error<T, T::Error>) {
         unifier.unifier.errors.error(error);
-    }
-
-    fn match_either<F, G>(unifier: &mut UnifierState<S, T, Self>,
-                          mut f: F,
-                          mut g: G)
-                          -> Result<Option<T>, ()>
-        where F: FnMut(&mut UnifierState<S, T, Self>) -> Result<Option<T>, ()>,
-              G: FnMut(&mut UnifierState<S, T, Self>) -> Result<Option<T>, ()>
-    {
-        let original_errors = unifier.unifier.errors.errors.len();
-        let result = f(unifier);
-        let first_errors = unifier.unifier.errors.errors.len();
-        // If there has been no error added the unification succeded
-        if result.is_ok() && original_errors == first_errors {
-            return result;
-        }
-        let result = g(unifier);
-        let last_errors = unifier.unifier.errors.errors.len();
-        if result.is_ok() && first_errors == last_errors {
-            // Remove any errors found from the first attempt to unify
-            for _ in original_errors..first_errors {
-                unifier.unifier
-                    .errors
-                    .errors
-                    .remove(original_errors);
-            }
-            return result;
-        }
-        for _ in first_errors..last_errors {
-            // Remove the errors from the second attempt (keeping the first attempt)
-            unifier.unifier
-                .errors
-                .errors
-                .remove(first_errors);
-        }
-        Err(())
     }
 
     fn try_match(unifier: &mut UnifierState<S, T, Self>, l: &T, r: &T) -> Option<T> {

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -212,7 +212,7 @@ impl<'m, S, T> Unifier<S, T> for Intersect<'m, T>
 
 #[cfg(test)]
 mod test {
-    use base::types::merge;
+    use base::types::{Walker, merge};
     use base::error::Errors;
 
     use super::{Error, Unifier, Unifiable, UnifierState};
@@ -240,20 +240,20 @@ mod test {
                 _ => None,
             }
         }
-        fn traverse<'s, F>(&'s self, mut f: F)
-            where F: FnMut(&'s Self) -> &'s Self
+        fn traverse<F>(&self, f: &mut F)
+            where F: Walker<Self>
         {
-            fn traverse_<'s>(typ: &'s TType, f: &mut FnMut(&'s TType) -> &'s TType) {
-                match *f(typ).0 {
+            fn traverse_(typ: &TType, f: &mut Walker<TType>) {
+                match *typ.0 {
                     Type::Arrow(ref a, ref r) => {
-                        traverse_(a, f);
-                        traverse_(r, f);
+                        f.walk(a);
+                        f.walk(r);
                     }
                     Type::Variable(_) |
                     Type::Id(_) => (),
                 }
             }
-            traverse_(self, &mut f)
+            traverse_(self, f)
         }
     }
 

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -1,9 +1,7 @@
 use std::fmt;
 
-use base::types;
-use base::types::{Type, merge};
 use base::ast::ASTType;
-use base::types::{TcType, TypeVariable, TypeEnv};
+use base::types::{self, TcType, Type, TypeVariable, TypeEnv, merge};
 use base::symbol::{Symbol, SymbolRef};
 use base::instantiate;
 
@@ -92,10 +90,10 @@ impl<I> Substitutable for ASTType<I> {
         }
     }
 
-    fn traverse<'s, F>(&'s self, mut f: F)
-        where F: FnMut(&'s ASTType<I>) -> &'s ASTType<I>
+    fn traverse<F>(&self, f: &mut F)
+        where F: types::Walker<ASTType<I>>
     {
-        types::walk_type(self, &mut f)
+        types::walk_type_(self, f)
     }
 }
 
@@ -386,8 +384,7 @@ mod tests {
     use unify::Error::*;
     use unify::unify;
     use substitution::Substitution;
-    use base::types;
-    use base::types::{TcType, Type};
+    use base::types::{self, TcType, Type};
     use tests::*;
 
 

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -35,7 +35,9 @@ pub fn intern(s: &str) -> Symbol {
     }
 }
 
-pub fn parse_new(s: &str) -> Result<ast::LExpr<TcIdent>, (Option<ast::LExpr<TcIdent>>, base::error::Errors<parser::Error>)> {
+pub fn parse_new(s: &str)
+                 -> Result<ast::LExpr<TcIdent>,
+                           (Option<ast::LExpr<TcIdent>>, ::base::error::Errors<::parser::Error>)> {
     let symbols = get_local_interner();
     let mut symbols = symbols.borrow_mut();
     let mut module = SymbolModule::new("test".into(), &mut symbols);


### PR DESCRIPTION
This PR should ensure that incredibly long generic names like `a00000001` does not occur anymore. It also includes some additional cleanup to the `check` crate and performance improvement when it comes to generalizing.

Closes #74