### PR TITLE
Clean up tests for check module

### DIFF
--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -4,74 +4,123 @@ extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
-use base::ast;
-use base::ast::Location;
+use base::ast::{self, Location};
 use base::types::{Type, TcType};
-
 use check::completion;
 
-mod functions;
-use functions::*;
+mod support;
+use support::typ;
 
 fn find_type(s: &str, location: Location) -> Result<TcType, ()> {
-    let (mut expr, result) = typecheck_expr(s);
+    let (mut expr, result) = support::typecheck_expr(s);
     assert!(result.is_ok(), "{}", result.unwrap_err());
     completion::find(&ast::EmptyEnv::new(), &mut expr, location)
 }
 
 fn suggest(s: &str, location: Location) -> Result<Vec<String>, ()> {
-    let (mut expr, _result) = typecheck_partial_expr(s);
+    let (mut expr, _result) = support::typecheck_partial_expr(s);
     let vec = completion::suggest(&ast::EmptyEnv::new(), &mut expr, location);
-    let mut vec: Vec<String> = vec.into_iter().map(|ident| ident.name.declared_name().to_string()).collect();
+    let mut vec: Vec<String> =
+        vec.into_iter().map(|ident| ident.name.declared_name().to_string()).collect();
     vec.sort();
     Ok(vec)
 }
 
 #[test]
 fn identifier() {
-    let (mut expr, result) = typecheck_expr("let abc = 1 in abc");
+    let (mut expr, result) = support::typecheck_expr("let abc = 1 in abc");
     assert!(result.is_ok(), "{}", result.unwrap_err());
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 1, column: 16, absolute: 0 });
-    assert_eq!(result, Ok(typ("Int")));
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 1, column: 17, absolute: 0 });
-    assert_eq!(result, Ok(typ("Int")));
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 1, column: 18, absolute: 0 });
-    assert_eq!(result, Ok(typ("Int")));
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 1, column: 19, absolute: 0 });
-    assert_eq!(result, Ok(typ("Int")));
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 1,
+                                      column: 16,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(typ("Int"));
+    assert_eq!(result, expected);
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 1,
+                                      column: 17,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(typ("Int"));
+    assert_eq!(result, expected);
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 1,
+                                      column: 18,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(typ("Int"));
+    assert_eq!(result, expected);
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 1,
+                                      column: 19,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(typ("Int"));
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn literal_string() {
-    let result = find_type(r#" "asd" "#, Location { row: 1, column: 2, absolute: 0 });
-    assert_eq!(result, Ok(typ("String")));
+    let result = find_type(r#" "asd" "#,
+                           Location {
+                               row: 1,
+                               column: 2,
+                               absolute: 0,
+                           });
+    let expected = Ok(typ("String"));
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn in_let() {
-    let result = find_type(
-r#"
+    let result = find_type(r#"
 let f x = 1
 and g x = "asd"
 1
-"#, Location { row: 3, column: 15, absolute: 0 });
-    assert_eq!(result, Ok(typ("String")));
+"#,
+                           Location {
+                               row: 3,
+                               column: 15,
+                               absolute: 0,
+                           });
+    let expected = Ok(typ("String"));
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn function_call() {
-    let result = find_type(
-r#"
+    let result = find_type(r#"
 let f x = f x
 1
-"#, Location { row: 2, column: 11, absolute: 0 });
-    assert_eq!(result, Ok(Type::function(vec![typ("a0")], typ("a1"))));
+"#,
+                           Location {
+                               row: 2,
+                               column: 11,
+                               absolute: 0,
+                           });
+    let expected = Ok(Type::function(vec![typ("a0")], typ("a1")));
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn binop() {
-    let (mut expr, result) = typecheck_expr(
-r#"
+    let (mut expr, result) = support::typecheck_expr(r#"
 let (++) l r =
     l #Int+ 1
     r #Float+ 1.0
@@ -79,105 +128,170 @@ let (++) l r =
 1 ++ 2.0
 "#);
     assert!(result.is_ok(), "{}", result.unwrap_err());
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 6, column: 4, absolute: 0 });
-    assert_eq!(result, Ok(Type::function(vec![typ("Int"), typ("Float")], typ("Int"))));
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 6, column: 1, absolute: 0 });
-    assert_eq!(result, Ok(typ("Int")));
-    let result = completion::find(&ast::EmptyEnv::new(), &mut expr, Location { row: 6, column: 6, absolute: 0 });
-    assert_eq!(result, Ok(typ("Float")));
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 6,
+                                      column: 4,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(Type::function(vec![typ("Int"), typ("Float")], typ("Int")));
+    assert_eq!(result, expected);
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 6,
+                                      column: 1,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(typ("Int"));
+    assert_eq!(result, expected);
+
+    let result = completion::find(&ast::EmptyEnv::new(),
+                                  &mut expr,
+                                  Location {
+                                      row: 6,
+                                      column: 6,
+                                      absolute: 0,
+                                  });
+    let expected = Ok(typ("Float"));
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn in_record() {
-    let result = find_type(
-r#"
+    let result = find_type(r#"
 {
     test = 123,
     s = "asd"
 }
-"#, Location { row: 3, column: 14, absolute: 0 });
-    assert_eq!(result, Ok(typ("Int")));
+"#,
+                           Location {
+                               row: 3,
+                               column: 14,
+                               absolute: 0,
+                           });
+    let expected = Ok(typ("Int"));
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_identifier_when_prefix() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 let test = 1
 let tes = ""
 let aaa = ""
 te
 "#,
-Location { row: 5, column: 1, absolute: 0 });
-    assert_eq!(result, Ok(vec!["tes".into(), "test".into()]));
+                         Location {
+                             row: 5,
+                             column: 1,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["tes".into(), "test".into()]);
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_arguments() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 let f test =
     \test2 -> tes
 123
 "#,
-Location { row: 3, column: 17, absolute: 0 });
-    assert_eq!(result, Ok(vec!["test".into(), "test2".into()]));
+                         Location {
+                             row: 3,
+                             column: 17,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["test".into(), "test2".into()]);
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_after_unrelated_type_error() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 let record = { aa = 1, ab = 2, c = "" }
 1.0 #Int+ 2
 record.a
 "#,
-Location { row: 4, column: 8, absolute: 0 });
-    assert_eq!(result, Ok(vec!["aa".into(), "ab".into()]));
+                         Location {
+                             row: 4,
+                             column: 8,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["aa".into(), "ab".into()]);
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_through_aliases() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 type Test a = { abc: a -> Int }
 type Test2 = Test String
 let record: Test2 = { abc = \x -> 0 }
 record.ab
 "#,
-Location { row: 5, column: 8, absolute: 0 });
-    assert_eq!(result, Ok(vec!["abc".into()]));
+                         Location {
+                             row: 5,
+                             column: 8,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["abc".into()]);
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_after_dot() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 let record = { aa = 1, ab = 2, c = "" }
 record.
 "#,
-Location { row: 3, column: 7, absolute: 0 });
-    assert_eq!(result, Ok(vec!["aa".into(), "ab".into(), "c".into()]));
+                         Location {
+                             row: 3,
+                             column: 7,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["aa".into(), "ab".into(), "c".into()]);
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_from_record_unpack() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 let { aa, c } = { aa = 1, ab = 2, c = "" }
 a
 "#,
-Location { row: 3, column: 7, absolute: 0 });
-    assert_eq!(result, Ok(vec!["aa".into()]));
+                         Location {
+                             row: 3,
+                             column: 7,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["aa".into()]);
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn suggest_on_record_in_field_access() {
-    let result = suggest(
-r#"
+    let result = suggest(r#"
 let record = { aa = 1, ab = 2, c = "" }
 record.aa
 "#,
-Location { row: 3, column: 4, absolute: 0 });
-    assert_eq!(result, Ok(vec!["record".into()]));
+                         Location {
+                             row: 3,
+                             column: 4,
+                             absolute: 0,
+                         });
+    let expected = Ok(vec!["record".into()]);
+
+    assert_eq!(result, expected);
 }

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -7,8 +7,7 @@ extern crate gluon_check as check;
 use base::ast;
 use base::types;
 
-mod functions;
-use functions::*;
+mod support;
 
 macro_rules! assert_err {
     ($e: expr, $($id: pat),+) => {{
@@ -17,7 +16,8 @@ macro_rules! assert_err {
         use check::unify::Error::{TypeMismatch, Occurs, Other};
         #[allow(unused_imports)]
         use check::unify_type::TypeError::FieldMismatch;
-        let symbols = get_local_interner();
+
+        let symbols = support::get_local_interner();
         match $e {
             Ok(x) => assert!(false, "Expected error, got {}",
                              types::display_type(&*symbols.borrow(), &x)),
@@ -43,7 +43,9 @@ macro_rules! assert_unify_err {
         use check::unify::Error::{TypeMismatch, Occurs, Other};
         #[allow(unused_imports)]
         use check::unify_type::TypeError::{FieldMismatch, SelfRecursive};
-        let symbols = get_local_interner();
+
+        let symbols = support::get_local_interner();
+
         match $e {
             Ok(x) => assert!(false, "Expected error, got {}",
                              types::display_type(&*symbols.borrow(), &x)),
@@ -77,18 +79,19 @@ macro_rules! assert_unify_err {
 
 #[test]
 fn record_missing_field() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r"
 match { x = 1 } with
 | { x, y } -> 1
 ";
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, UndefinedField(..));
 }
 
 #[test]
 fn undefined_type() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 let x =
     type Test = | Test String Int
@@ -97,99 +100,107 @@ in
 type Test2 = Test
 in x
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, UndefinedType(..));
 }
 
 #[test]
 fn undefined_variant() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 let x =
     type Test = | Test String Int
     { Test, x = 1 }
 Test "" 2
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, UndefinedVariable(..));
 }
 
 #[test]
 fn mutually_recursive_types_error() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 type List a = | Empty | Node (a (Data a))
 and Data a = { value: a, list: List a }
 in 1
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, KindError(TypeMismatch(..)));
 }
 
 #[test]
 fn unpack_field_which_does_not_exist() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 let { y } = { x = 1 }
 2
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, UndefinedField(..));
 }
 
 #[test]
 fn duplicate_type_definition() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 type Test = Int
 in
 type Test = Float
 in 1
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, DuplicateTypeDefinition(..));
 }
 
 #[test]
 fn no_matching_overloaded_binding() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 let f x = x #Int+ 1
 in
 let f x = x #Float+ 1.0
 in f ""
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, Rename(..));
 }
 
 #[test]
 fn no_matching_binop_binding() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 let (++) x y = x #Int+ y
 let (++) x y = x #Float+ y
 "" ++ ""
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, Rename(..));
 }
 
 #[test]
 fn not_enough_information_to_decide_overload() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 let f x = x #Int+ 1
 let f x = x #Float+ 1.0
 \x -> f x
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_err!(result, Rename(..));
 }
 
 #[test]
 fn type_field_mismatch() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 if True then
     type Test = Int
@@ -198,13 +209,14 @@ else
     type Test = Float
     { Test }
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_unify_err!(result, TypeMismatch(..));
 }
 
 #[test]
 fn arguments_need_to_be_instantiated_before_any_access() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     // test_fn: forall a. (a -> ()) -> ()
     // To allow any type to be passed to `f` it should be
     // test_fn: (forall a. a -> ()) -> ()
@@ -213,13 +225,14 @@ let test_fn f: (a -> ()) -> () =
     f 2.0
 1
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_unify_err!(result, TypeMismatch(..));
 }
 
 #[test]
 fn infer_ord_int() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r#"
 type Ordering = | LT | EQ | GT
 type Ord a = {
@@ -246,13 +259,14 @@ let (<=) = (make_Ord ord_Int).(<=)
 
 "" <= ""
 "#;
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_unify_err!(result, TypeMismatch(..), TypeMismatch(..));
 }
 
 #[test]
 fn recursive_types_with_differing_aliases() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r"
 type Option a = | None | Some a
 type R1 = Option R1
@@ -262,19 +276,21 @@ let x: R1 = None
 let y: R2 = x
 y
 ";
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_unify_err!(result, Other(SelfRecursive(..)));
 }
 
 #[test]
 fn detect_self_recursive_aliases() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
     let text = r"
 type A a = A a
 
 let g x: A a -> () = x
 1
 ";
-    let result = typecheck(text);
+    let result = support::typecheck(text);
+
     assert_unify_err!(result, Other(SelfRecursive(..)));
 }

--- a/check/tests/metadata.rs
+++ b/check/tests/metadata.rs
@@ -1,66 +1,73 @@
-
 extern crate env_logger;
 
 extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
-mod functions;
-use functions::*;
-
 use base::metadata::Metadata;
-use check::metadata::*;
+use check::metadata::metadata;
+
+mod support;
 
 #[test]
 fn propagate_metadata_let_in() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
+
     let text = r#"
 /// The identity function
 let id x = x
 id
 "#;
-    let (mut expr, result) = typecheck_expr(text);
+    let (mut expr, result) = support::typecheck_expr(text);
+
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
     let metadata = metadata(&(), &mut expr);
-    assert_eq!(metadata, Metadata {
-        comment: Some("The identity function".into()),
-        module: Default::default(),
-    });
+    assert_eq!(metadata,
+               Metadata {
+                   comment: Some("The identity function".into()),
+                   module: Default::default(),
+               });
 }
 
 #[test]
 fn propagate_metadata_let_record() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
+
     let text = r#"
 /// The identity function
 let id x = x
 { id }
 "#;
-    let (mut expr, result) = typecheck_expr(text);
+    let (mut expr, result) = support::typecheck_expr(text);
+
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
     let metadata = metadata(&(), &mut expr);
-    assert_eq!(metadata.module.get("id"), Some(&Metadata {
-        comment: Some("The identity function".into()),
-        module: Default::default(),
-    }));
+    assert_eq!(metadata.module.get("id"),
+               Some(&Metadata {
+                   comment: Some("The identity function".into()),
+                   module: Default::default(),
+               }));
 }
 
 #[test]
 fn propagate_metadata_type_record() {
-    let _ = ::env_logger::init();
+    let _ = env_logger::init();
+
     let text = r#"
 /// A test type
 type Test = Int
 { Test }
 "#;
-    let (mut expr, result) = typecheck_expr(text);
+    let (mut expr, result) = support::typecheck_expr(text);
+
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
     let metadata = metadata(&(), &mut expr);
-    assert_eq!(metadata.module.get("Test"), Some(&Metadata {
-        comment: Some("A test type".into()),
-        module: Default::default(),
-    }));
+    assert_eq!(metadata.module.get("Test"),
+               Some(&Metadata {
+                   comment: Some("A test type".into()),
+                   module: Default::default(),
+               }));
 }

--- a/check/tests/stack_overflow.rs
+++ b/check/tests/stack_overflow.rs
@@ -2,12 +2,11 @@ extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
-mod functions;
-use functions::*;
+mod support;
 
 #[test]
 fn dont_stack_overflow_on_let_bindings() {
-let text = r#"
+    let text = r#"
 let _ = 1
 in
 let _ = 1
@@ -734,5 +733,5 @@ in
 let _ = 1
 in 1
 "#;
-    typecheck(text).unwrap();
+    support::typecheck(text).unwrap();
 }


### PR DESCRIPTION
- Moved common functions to a support module, as is common in most Rust projects.
- Prefer qualifying functions by module, and remove glob imports.
- Assign most expected values to `expected` binding before asserting equality.