### PR TITLE
Print type along with value when when evaluating in the repl

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -366,7 +366,7 @@ Once in possession of a [RootedThread][] you can compile and execute code using 
 
 ```rust,ignore
 let vm = new_vm();
-let result = Compiler::new()
+let (result, _) = Compiler::new()
     .run_expr::<i32>(&vm, "example", "1 + 2")
     .ok();
 assert_eq!(result, Some(3));
@@ -397,7 +397,7 @@ fn factorial(x: i32) -> i32 {
 let vm = new_vm();
 vm.define_global("factorial", factorial as fn (_) -> _)
     .unwrap();
-let result = Compiler::new()
+let (result, _) = Compiler::new()
     .run_expr::<i32>(&vm, "example", "factorial 5")
     .unwrap();
 assert_eq!(result, 120);
@@ -407,7 +407,7 @@ assert_eq!(result, 120);
 
 ```rust,ignore
 let vm = new_vm();
-let result = Compiler::new()
+let (result, _) = Compiler::new()
     .run_expr::<String>(&vm, "example", " let string = import \"std/string.glu\" in string.trim \"  Hello world  \t\" ")
     .unwrap();
 assert_eq!(result, "Hello world");

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn glu_run_expr(vm: &Thread,
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    let result: Result<Generic<A>, _> = Compiler::new().run_expr(&vm, module, expr);
+    let result = Compiler::new().run_expr::<Generic<A>>(&vm, module, expr);
     match result {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,4 @@
 use std::string::String as StdString;
-use std::result::Result as StdResult;
 use std::io::{Read, stdin};
 use std::fmt;
 use std::fs::File;
@@ -152,10 +151,10 @@ fn run_expr(expr: WithVM<RootStr>) -> IO<String> {
     let mut stack = vm.current_frame();
     let frame_level = stack.stack.get_frames().len();
     drop(stack);
-    let run_result: StdResult<Generic<A>, _> = Compiler::new().run_expr(vm, "<top>", &expr);
+    let run_result = Compiler::new().run_expr::<Generic<A>>(vm, "<top>", &expr);
     stack = vm.current_frame();
     match run_result {
-        Ok(value) => IO::Value(format!("{:?}", value.0)),
+        Ok((value, typ)) => IO::Value(format!("{:?} : {}", value.0, typ)),
         Err(err) => {
             let trace = stack.stacktrace(frame_level);
             let fmt = format!("{}\n{}", err, trace);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,26 +463,30 @@ impl Compiler {
 
     /// Compiles and runs the expression in `expr_str`. If successful the value from running the
     /// expression is returned
-    pub fn run_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<T>
+    pub fn run_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<(T, TcType)>
         where T: Getable<'vm> + VMType
     {
         let expected = T::make_type(vm);
         let (value, actual) = try!(self.run_expr_(vm, name, expr_str, Some(&expected)));
         unsafe {
-            T::from_value(vm, Variants::new(&value))
-                .ok_or_else(move || Error::from(VMError::WrongType(expected, actual)))
+            match T::from_value(vm, Variants::new(&value)) {
+                Some(value) => Ok((value, actual)),
+                None => Err(Error::from(VMError::WrongType(expected, actual))),
+            }
         }
     }
 
-    pub fn run_io_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<T>
+    pub fn run_io_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<(T, TcType)>
         where T: Getable<'vm> + VMType,
               T::Type: Sized
     {
         let expected = IO::<T>::make_type(vm);
         let (value, actual) = try!(self.run_expr_(vm, name, expr_str, Some(&expected)));
         unsafe {
-            T::from_value(vm, Variants::new(&value))
-                .ok_or_else(move || Error::from(VMError::WrongType(expected, actual)))
+            match T::from_value(vm, Variants::new(&value)) {
+                Some(value) => Ok((value, actual)),
+                None => Err(Error::from(VMError::WrongType(expected, actual))),
+            }
         }
     }
 

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -21,8 +21,7 @@ fn read_file() {
             assert (array.index bytes 1 #Byte== 112b) // p
             pure (array.index bytes 8)
         "#;
-    let result = Compiler::new()
-        .run_io_expr::<u8>(&thread, "<top>", text);
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-    assert_eq!(result.unwrap(), b']');
+    let (result, _) = Compiler::new().run_io_expr::<u8>(&thread, "<top>", text).unwrap();
+
+    assert_eq!(result, b']');
 }

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -18,7 +18,7 @@ fn parallel() {
 fn parallel_() -> Result<(), Error> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    let value = try!(compiler.run_expr(&vm, "<top>", " channel 0 "));
+    let (value, _) = try!(compiler.run_expr(&vm, "<top>", " channel 0 "));
     let value: ChannelRecord<OpaqueValue<RootedThread, Sender<i32>>, OpaqueValue<RootedThread, Receiver<i32>>> = value;
     let (sender, receiver) = value.split();
 
@@ -32,7 +32,7 @@ fn parallel_() -> Result<(), Error> {
         f
         "#;
         let mut compiler = Compiler::new();
-        let mut f: FunctionRef<fn (OpaqueValue<RootedThread, Sender<i32>>)> = try!(compiler.run_expr(&child, "<top>", expr));
+        let mut f: FunctionRef<fn (OpaqueValue<RootedThread, Sender<i32>>)> = try!(compiler.run_expr(&child, "<top>", expr)).0;
         Ok(try!(f.call(sender)))
     });
 
@@ -50,7 +50,7 @@ fn parallel_() -> Result<(), Error> {
         f
         "#;
         let mut compiler = Compiler::new();
-        let mut f: FunctionRef<fn (OpaqueValue<RootedThread, Receiver<i32>>)> = try!(compiler.run_expr(&child2, "<top>", expr));
+        let mut f: FunctionRef<fn (OpaqueValue<RootedThread, Receiver<i32>>)> = try!(compiler.run_expr(&child2, "<top>", expr)).0;
         Ok(try!(f.call(receiver)))
     });
 

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -1,6 +1,7 @@
 extern crate env_logger;
 extern crate gluon;
 
+use gluon::base::types::Type;
 use gluon::vm::api::generic::A;
 use gluon::vm::api::{FunctionRef, Generic};
 use gluon::RootedThread;
@@ -29,27 +30,32 @@ fn access_field_through_alias() {
     let result = add.call(1, 2);
     assert_eq!(result, Ok(3));
 }
+
 #[test]
 fn call_rust_from_gluon() {
     let _ = ::env_logger::init();
+
     fn factorial(x: i32) -> i32 {
         if x <= 1 { 1 } else { x * factorial(x - 1) }
     }
     let vm = new_vm();
-    vm.define_global("factorial", factorial as fn (_) -> _)
-        .unwrap();
-    let result = Compiler::new()
-        .run_expr::<i32>(&vm, "example", "factorial 5")
-        .unwrap();
-    assert_eq!(result, 120);
+    vm.define_global("factorial", factorial as fn (_) -> _).unwrap();
+
+    let result = Compiler::new().run_expr::<i32>(&vm, "example", "factorial 5").unwrap();
+    let expected = (120, Type::int());
+
+    assert_eq!(result, expected);
 }
 
 #[test]
 fn use_string_module() {
     let _ = ::env_logger::init();
+
     let vm = new_vm();
     let result = Compiler::new()
         .run_expr::<String>(&vm, "example", " let string = import \"std/string.glu\" in string.trim \"  Hello world  \t\" ")
         .unwrap();
-    assert_eq!(result, "Hello world");
+    let expected = ("Hello world".to_string(), Type::string());
+
+    assert_eq!(result, expected);
 }

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -23,7 +23,7 @@ pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
     Compiler::new()
         .implicit_prelude(implicit_prelude)
         .run_expr(vm, "<top>", s)
-        .unwrap_or_else(|err| panic!("{}", err))
+        .unwrap_or_else(|err| panic!("{}", err)).0
 }
 
 pub fn run_expr<'vm, T>(vm: &'vm Thread, s: &str) -> T
@@ -62,7 +62,7 @@ macro_rules! test_expr {
         fn $name() {
             let _ = ::env_logger::init();
             let mut vm = make_vm();
-            let value = Compiler::new()
+            let (value, _) = Compiler::new()
                 .implicit_prelude(false)
                 .run_io_expr(&mut vm, "<top>", $expr)
                 .unwrap_or_else(|err| panic!("{}", err));
@@ -631,10 +631,13 @@ in id 1
 #[test]
 fn run_expr_int() {
     let _ = ::env_logger::init();
+
     let text = r#"io.run_expr "123" "#;
     let mut vm = make_vm();
-    let result = Compiler::new().run_io_expr::<String>(&mut vm, "<top>", text).unwrap();
-    assert_eq!(result, String::from("123"));
+    let (result, _) = Compiler::new().run_io_expr::<String>(&mut vm, "<top>", text).unwrap();
+    let expected = "123 : Int";
+
+    assert_eq!(result, expected);
 }
 
 test_expr!{ io run_expr_io,
@@ -645,6 +648,7 @@ r#"io_flat_map (\x -> io_pure 100) (io.run_expr "io.print_int 123") "#,
 #[test]
 fn rename_types_after_binding() {
     let _ = ::env_logger::init();
+
     let text = r#"
 let prelude = import "std/prelude.glu"
 in
@@ -653,10 +657,12 @@ and { (==) }: Eq (List Int) = prelude.eq_List { (==) }
 in Cons 1 Nil == Nil
 "#;
     let mut vm = make_vm();
-    let value = Compiler::new()
+    let (result, _) = Compiler::new()
                     .run_expr::<bool>(&mut vm, "<top>", text)
                     .unwrap_or_else(|err| panic!("{}", err));
-    assert_eq!(value, false);
+    let expected = false;
+
+    assert_eq!(result, expected);
 }
 
 #[test]


### PR DESCRIPTION
Closes #83 

Note that this changes `run_expr` and `run_io_expr` to return the inferred type along with the value. Not sure if that's ok :/