### PR TITLE
Remove Typed::type_of function

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Deref;
 use symbol::Symbol;
-use types::{self, Alias, AliasData, EmptyTypeEnv, Kind, Type, TypeEnv, TypeVariable};
+use types::{self, Alias, AliasData, Kind, Type, TypeEnv, TypeVariable};
 
 pub type ASTType<Id> = ::types::ArcType<Id>;
 
@@ -555,10 +555,6 @@ pub fn walk_mut_pattern<V: ?Sized + MutVisitor>(v: &mut V, p: &mut Pattern<V::T>
 /// It is not guaranteed that the correct type is returned until after typechecking
 pub trait Typed {
     type Id;
-
-    fn type_of(&self) -> ASTType<Self::Id> {
-        self.env_type_of(&EmptyTypeEnv)
-    }
 
     fn env_type_of(&self, env: &TypeEnv) -> ASTType<Self::Id>;
 }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -14,13 +14,15 @@ use symbol::{Symbol, SymbolRef};
 pub type TcType = ast::ASTType<Symbol>;
 pub type TcIdent = ast::TcIdent<Symbol>;
 
+pub struct EmptyTypeEnv;
+
 /// Trait for values which contains kinded values which can be refered by name
 pub trait KindEnv {
     /// Returns the kind of the type `type_name`
     fn find_kind(&self, type_name: &SymbolRef) -> Option<RcKind>;
 }
 
-impl KindEnv for () {
+impl KindEnv for EmptyTypeEnv {
     fn find_kind(&self, _type_name: &SymbolRef) -> Option<RcKind> {
         None
     }
@@ -57,7 +59,7 @@ pub trait TypeEnv: KindEnv {
     fn find_record(&self, fields: &[Symbol]) -> Option<(&TcType, &TcType)>;
 }
 
-impl TypeEnv for () {
+impl TypeEnv for EmptyTypeEnv {
     fn find_type(&self, _id: &SymbolRef) -> Option<&TcType> {
         None
     }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -13,18 +13,10 @@ use symbol::{Symbol, SymbolRef};
 pub type TcType = ast::ASTType<Symbol>;
 pub type TcIdent = ast::TcIdent<Symbol>;
 
-pub struct EmptyTypeEnv;
-
 /// Trait for values which contains kinded values which can be refered by name
 pub trait KindEnv {
     /// Returns the kind of the type `type_name`
     fn find_kind(&self, type_name: &SymbolRef) -> Option<RcKind>;
-}
-
-impl KindEnv for EmptyTypeEnv {
-    fn find_kind(&self, _type_name: &SymbolRef) -> Option<RcKind> {
-        None
-    }
 }
 
 impl<'a, T: ?Sized + KindEnv> KindEnv for &'a T {
@@ -50,18 +42,6 @@ pub trait TypeEnv: KindEnv {
     /// Returns a record which contains all `fields`. The first element is the record type and the
     /// second is the alias type.
     fn find_record(&self, fields: &[Symbol]) -> Option<(&TcType, &TcType)>;
-}
-
-impl TypeEnv for EmptyTypeEnv {
-    fn find_type(&self, _id: &SymbolRef) -> Option<&TcType> {
-        None
-    }
-    fn find_type_info(&self, _id: &SymbolRef) -> Option<&Alias<Symbol, TcType>> {
-        None
-    }
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(&TcType, &TcType)> {
-        None
-    }
 }
 
 impl<'a, T: ?Sized + TypeEnv> TypeEnv for &'a T {

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -25,20 +25,14 @@ impl<'a, T: ?Sized + KindEnv> KindEnv for &'a T {
     }
 }
 
-impl<T: KindEnv, U: KindEnv> KindEnv for (T, U) {
-    fn find_kind(&self, id: &SymbolRef) -> Option<RcKind> {
-        let &(ref outer, ref inner) = self;
-        inner.find_kind(id)
-            .or_else(|| outer.find_kind(id))
-    }
-}
-
 /// Trait for values which contains typed values which can be refered by name
 pub trait TypeEnv: KindEnv {
     /// Returns the type of the value bound at `id`
     fn find_type(&self, id: &SymbolRef) -> Option<&TcType>;
+
     /// Returns information about the type `id`
     fn find_type_info(&self, id: &SymbolRef) -> Option<&Alias<Symbol, TcType>>;
+
     /// Returns a record which contains all `fields`. The first element is the record type and the
     /// second is the alias type.
     fn find_record(&self, fields: &[Symbol]) -> Option<(&TcType, &TcType)>;
@@ -48,29 +42,13 @@ impl<'a, T: ?Sized + TypeEnv> TypeEnv for &'a T {
     fn find_type(&self, id: &SymbolRef) -> Option<&TcType> {
         (**self).find_type(id)
     }
+
     fn find_type_info(&self, id: &SymbolRef) -> Option<&Alias<Symbol, TcType>> {
         (**self).find_type_info(id)
     }
+
     fn find_record(&self, fields: &[Symbol]) -> Option<(&TcType, &TcType)> {
         (**self).find_record(fields)
-    }
-}
-
-impl<T: TypeEnv, U: TypeEnv> TypeEnv for (T, U) {
-    fn find_type(&self, id: &SymbolRef) -> Option<&TcType> {
-        let &(ref outer, ref inner) = self;
-        inner.find_type(id)
-            .or_else(|| outer.find_type(id))
-    }
-    fn find_type_info(&self, id: &SymbolRef) -> Option<&Alias<Symbol, TcType>> {
-        let &(ref outer, ref inner) = self;
-        inner.find_type_info(id)
-            .or_else(|| outer.find_type_info(id))
-    }
-    fn find_record(&self, fields: &[Symbol]) -> Option<(&TcType, &TcType)> {
-        let &(ref outer, ref inner) = self;
-        inner.find_record(fields)
-            .or_else(|| outer.find_record(fields))
     }
 }
 
@@ -83,12 +61,6 @@ pub trait PrimitiveEnv: TypeEnv {
 impl<'a, T: ?Sized + PrimitiveEnv> PrimitiveEnv for &'a T {
     fn get_bool(&self) -> &TcType {
         (**self).get_bool()
-    }
-}
-
-impl<'a, T: PrimitiveEnv, U: TypeEnv> PrimitiveEnv for (T, U) {
-    fn get_bool(&self) -> &TcType {
-        self.0.get_bool()
     }
 }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -1,6 +1,5 @@
 //! Module containing types representing `gluon`'s type system
 use std::borrow::ToOwned;
-use std::collections::HashMap;
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -39,12 +38,6 @@ impl<T: KindEnv, U: KindEnv> KindEnv for (T, U) {
         let &(ref outer, ref inner) = self;
         inner.find_kind(id)
             .or_else(|| outer.find_kind(id))
-    }
-}
-
-impl KindEnv for HashMap<String, TcType> {
-    fn find_kind(&self, _type_name: &SymbolRef) -> Option<RcKind> {
-        None
     }
 }
 
@@ -98,18 +91,6 @@ impl<T: TypeEnv, U: TypeEnv> TypeEnv for (T, U) {
         let &(ref outer, ref inner) = self;
         inner.find_record(fields)
             .or_else(|| outer.find_record(fields))
-    }
-}
-
-impl TypeEnv for HashMap<String, TcType> {
-    fn find_type(&self, id: &SymbolRef) -> Option<&TcType> {
-        self.get(id.as_ref())
-    }
-    fn find_type_info(&self, _id: &SymbolRef) -> Option<&Alias<Symbol, TcType>> {
-        None
-    }
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(&TcType, &TcType)> {
-        None
     }
 }
 

--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -1,55 +1,58 @@
 //! Primitive auto completion and type quering on ASTs
-use std::iter::once;
 
-use base::ast;
-use base::scoped_map::ScopedMap;
+use std::iter::once;
 use std::cmp::Ordering;
 
-use base::ast::{DisplayEnv, Location, Typed};
-use base::symbol::Symbol;
-use base::types::{EmptyTypeEnv, Type, TcType};
+use base::ast::{self, DisplayEnv, Expr, LExpr, Location, LPattern, Pattern, TcIdent, Typed};
 use base::instantiate;
+use base::scoped_map::ScopedMap;
+use base::symbol::Symbol;
+use base::types::{TcType, Type, TypeEnv};
 
 trait OnFound {
-    fn on_ident(&mut self, ident: &ast::TcIdent<Symbol>) {
+    fn on_ident(&mut self, ident: &TcIdent<Symbol>) {
         let _ = ident;
     }
-    fn on_expr(&mut self, expr: &ast::LExpr<ast::TcIdent<Symbol>>) {
-        let _ = expr;
-    }
-    fn on_pattern(&mut self, pattern: &ast::LPattern<ast::TcIdent<Symbol>>) {
+
+    fn on_pattern(&mut self, pattern: &LPattern<TcIdent<Symbol>>) {
         let _ = pattern;
     }
 
-    fn expr(&mut self, expr: &ast::LExpr<ast::TcIdent<Symbol>>);
-    fn ident(&mut self, context: &ast::LExpr<ast::TcIdent<Symbol>>, ident: &ast::TcIdent<Symbol>);
+    fn expr(&mut self, expr: &LExpr<TcIdent<Symbol>>);
+
+    fn ident(&mut self, context: &LExpr<TcIdent<Symbol>>, ident: &TcIdent<Symbol>);
 }
 
-struct GetType(Option<TcType>);
-impl OnFound for GetType {
-    fn expr(&mut self, expr: &ast::LExpr<ast::TcIdent<Symbol>>) {
-        self.0 = Some(expr.type_of());
+struct GetType<'a, T: TypeEnv + 'a> {
+    env: &'a T,
+    typ: Option<TcType>,
+}
+
+impl<'a, T: TypeEnv + 'a> OnFound for GetType<'a, T> {
+    fn expr(&mut self, expr: &LExpr<TcIdent<Symbol>>) {
+        self.typ = Some(expr.env_type_of(self.env));
     }
-    fn ident(&mut self,
-             _context: &ast::LExpr<ast::TcIdent<Symbol>>,
-             ident: &ast::TcIdent<Symbol>) {
-        self.0 = Some(ident.type_of());
+
+    fn ident(&mut self, _context: &LExpr<TcIdent<Symbol>>, ident: &TcIdent<Symbol>) {
+        self.typ = Some(ident.env_type_of(self.env));
     }
 }
 
-struct Suggest {
+struct Suggest<'a, T: TypeEnv + 'a> {
+    env: &'a T,
     stack: ScopedMap<Symbol, TcType>,
-    result: Vec<ast::TcIdent<Symbol>>,
+    result: Vec<TcIdent<Symbol>>,
 }
-impl OnFound for Suggest {
-    fn on_ident(&mut self, ident: &ast::TcIdent<Symbol>) {
+
+impl<'a, T: TypeEnv + 'a> OnFound for Suggest<'a, T> {
+    fn on_ident(&mut self, ident: &TcIdent<Symbol>) {
         self.stack.insert(ident.name.clone(), ident.typ.clone());
     }
 
-    fn on_pattern(&mut self, pattern: &ast::LPattern<ast::TcIdent<Symbol>>) {
+    fn on_pattern(&mut self, pattern: &LPattern<TcIdent<Symbol>>) {
         match pattern.value {
-            ast::Pattern::Record { ref id, fields: ref field_ids, .. } => {
-                let unaliased = instantiate::remove_aliases(&EmptyTypeEnv, id.typ.clone());
+            Pattern::Record { ref id, fields: ref field_ids, .. } => {
+                let unaliased = instantiate::remove_aliases(self.env, id.typ.clone());
                 if let Type::Record { ref fields, .. } = *unaliased {
                     for (field, field_type) in field_ids.iter().zip(fields) {
                         let f = field.1.as_ref().unwrap_or(&field.0).clone();
@@ -57,10 +60,10 @@ impl OnFound for Suggest {
                     }
                 }
             }
-            ast::Pattern::Identifier(ref id) => {
+            Pattern::Identifier(ref id) => {
                 self.stack.insert(id.name.clone(), id.typ.clone());
             }
-            ast::Pattern::Constructor(_, ref args) => {
+            Pattern::Constructor(_, ref args) => {
                 for arg in args {
                     self.stack.insert(arg.name.clone(), arg.typ.clone());
                 }
@@ -68,11 +71,11 @@ impl OnFound for Suggest {
         }
     }
 
-    fn expr(&mut self, expr: &ast::LExpr<ast::TcIdent<Symbol>>) {
-        if let ast::Expr::Identifier(ref ident) = expr.value {
+    fn expr(&mut self, expr: &LExpr<TcIdent<Symbol>>) {
+        if let Expr::Identifier(ref ident) = expr.value {
             for (k, typ) in self.stack.iter() {
                 if k.declared_name().starts_with(ident.name.declared_name()) {
-                    self.result.push(ast::TcIdent {
+                    self.result.push(TcIdent {
                         name: k.clone(),
                         typ: typ.clone(),
                     });
@@ -81,14 +84,14 @@ impl OnFound for Suggest {
         }
     }
 
-    fn ident(&mut self, context: &ast::LExpr<ast::TcIdent<Symbol>>, ident: &ast::TcIdent<Symbol>) {
-        if let ast::Expr::FieldAccess(ref expr, _) = context.value {
-            let typ = expr.type_of();
-            if let Type::Record { ref fields, .. } = *instantiate::remove_aliases(&EmptyTypeEnv, typ) {
+    fn ident(&mut self, context: &LExpr<TcIdent<Symbol>>, ident: &TcIdent<Symbol>) {
+        if let Expr::FieldAccess(ref expr, _) = context.value {
+            let typ = instantiate::remove_aliases(self.env, expr.env_type_of(self.env));
+            if let Type::Record { ref fields, .. } = *typ {
                 let id = ident.name.as_ref();
                 for field in fields {
                     if field.name.as_ref().starts_with(id) {
-                        self.result.push(ast::TcIdent {
+                        self.result.push(TcIdent {
                             name: field.name.clone(),
                             typ: field.typ.clone(),
                         });
@@ -100,7 +103,7 @@ impl OnFound for Suggest {
 }
 
 struct FindVisitor<'a, F> {
-    env: &'a (DisplayEnv<Ident = ast::TcIdent<Symbol>> + 'a),
+    env: &'a (DisplayEnv<Ident = TcIdent<Symbol>> + 'a),
     location: Location,
     on_found: F,
 }
@@ -138,17 +141,19 @@ impl<'a, F> FindVisitor<'a, F>
     where F: OnFound
 {
     fn visit_one<'e, I>(&mut self, iter: I)
-        where I: IntoIterator<Item = &'e ast::LExpr<ast::TcIdent<Symbol>>>
+        where I: IntoIterator<Item = &'e LExpr<TcIdent<Symbol>>>
     {
         let (_, expr) = self.select_spanned(iter, |e| e.span(self.env));
         self.visit_expr(expr.unwrap());
     }
 
-    fn visit_pattern(&mut self, pattern: &ast::LPattern<ast::TcIdent<Symbol>>) {
+    fn visit_pattern(&mut self, pattern: &LPattern<TcIdent<Symbol>>) {
         self.on_found.on_pattern(pattern);
     }
-    fn visit_expr(&mut self, current: &ast::LExpr<ast::TcIdent<Symbol>>) {
+
+    fn visit_expr(&mut self, current: &LExpr<TcIdent<Symbol>>) {
         use base::ast::Expr::*;
+
         match current.value {
             Identifier(_) | Literal(_) => self.on_found.expr(current),
             Call(ref func, ref args) => {
@@ -212,27 +217,39 @@ impl<'a, F> FindVisitor<'a, F>
     }
 }
 
-pub fn find(env: &DisplayEnv<Ident = ast::TcIdent<Symbol>>,
-            expr: &ast::LExpr<ast::TcIdent<Symbol>>,
-            location: Location)
-            -> Result<TcType, ()> {
+pub fn find<D, T>(env: &D,
+                  typ_env: &T,
+                  expr: &LExpr<TcIdent<Symbol>>,
+                  location: Location)
+                  -> Result<TcType, ()>
+    where D: DisplayEnv<Ident = TcIdent<Symbol>>,
+          T: TypeEnv
+{
     let mut visitor = FindVisitor {
         env: env,
         location: location,
-        on_found: GetType(None),
+        on_found: GetType {
+            env: typ_env,
+            typ: None,
+        },
     };
     visitor.visit_expr(expr);
-    visitor.on_found.0.ok_or(())
+    visitor.on_found.typ.ok_or(())
 }
 
-pub fn suggest(env: &DisplayEnv<Ident = ast::TcIdent<Symbol>>,
-               expr: &ast::LExpr<ast::TcIdent<Symbol>>,
-               location: Location)
-               -> Vec<ast::TcIdent<Symbol>> {
+pub fn suggest<D, T>(env: &D,
+                     typ_env: &T,
+                     expr: &LExpr<TcIdent<Symbol>>,
+                     location: Location)
+                     -> Vec<TcIdent<Symbol>>
+    where D: DisplayEnv<Ident = TcIdent<Symbol>>,
+          T: TypeEnv
+{
     let mut visitor = FindVisitor {
         env: env,
         location: location,
         on_found: Suggest {
+            env: typ_env,
             stack: ScopedMap::new(),
             result: Vec::new(),
         },

--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 
 use base::ast::{DisplayEnv, Location, Typed};
 use base::symbol::Symbol;
-use base::types::{Type, TcType};
+use base::types::{EmptyTypeEnv, Type, TcType};
 use base::instantiate;
 
 trait OnFound {
@@ -49,7 +49,7 @@ impl OnFound for Suggest {
     fn on_pattern(&mut self, pattern: &ast::LPattern<ast::TcIdent<Symbol>>) {
         match pattern.value {
             ast::Pattern::Record { ref id, fields: ref field_ids, .. } => {
-                let unaliased = instantiate::remove_aliases(&(), id.typ.clone());
+                let unaliased = instantiate::remove_aliases(&EmptyTypeEnv, id.typ.clone());
                 if let Type::Record { ref fields, .. } = *unaliased {
                     for (field, field_type) in field_ids.iter().zip(fields) {
                         let f = field.1.as_ref().unwrap_or(&field.0).clone();
@@ -84,7 +84,7 @@ impl OnFound for Suggest {
     fn ident(&mut self, context: &ast::LExpr<ast::TcIdent<Symbol>>, ident: &ast::TcIdent<Symbol>) {
         if let ast::Expr::FieldAccess(ref expr, _) = context.value {
             let typ = expr.type_of();
-            if let Type::Record { ref fields, .. } = *instantiate::remove_aliases(&(), typ) {
+            if let Type::Record { ref fields, .. } = *instantiate::remove_aliases(&EmptyTypeEnv, typ) {
                 let id = ident.name.as_ref();
                 for field in fields {
                     if field.name.as_ref().starts_with(id) {

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -26,7 +26,28 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    use base::symbol::{Symbols, SymbolModule, Symbol};
+    use base::types::{Alias, KindEnv, RcKind, TcType, TypeEnv};
+    use base::symbol::{Symbol, Symbols, SymbolModule, SymbolRef};
+
+    pub struct MockEnv;
+
+    impl KindEnv for MockEnv {
+        fn find_kind(&self, _type_name: &SymbolRef) -> Option<RcKind> {
+            None
+        }
+    }
+
+    impl TypeEnv for MockEnv {
+        fn find_type(&self, _id: &SymbolRef) -> Option<&TcType> {
+            None
+        }
+        fn find_type_info(&self, _id: &SymbolRef) -> Option<&Alias<Symbol, TcType>> {
+            None
+        }
+        fn find_record(&self, _fields: &[Symbol]) -> Option<(&TcType, &TcType)> {
+            None
+        }
+    }
 
     /// Returns a reference to the interner stored in TLD
     pub fn get_local_interner() -> Rc<RefCell<Symbols>> {

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -256,7 +256,7 @@ pub fn rename(symbols: &mut SymbolModule,
                     if is_recursive {
                         for bind in bindings {
                             self.env.stack.enter_scope();
-                            for (typ, arg) in types::arg_iter(&bind.type_of())
+                            for (typ, arg) in types::arg_iter(&bind.env_type_of(&self.env))
                                 .zip(&mut bind.arguments) {
                                 arg.name =
                                     self.stack_var(arg.name.clone(), expr.location, typ.clone());

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -884,10 +884,11 @@ impl<'a> Typecheck<'a> {
             }
         }
         if is_recursive {
-            for (typ, bind) in types.into_iter().zip(bindings.iter_mut()) {
+            for (found_typ, bind) in types.into_iter().zip(bindings.iter_mut()) {
                 // Merge the variable we bound to the name and the type inferred
                 // in the expression
-                self.unify_span(bind.name.span(), &bind.type_of().clone(), typ);
+                let bound_typ = bind.env_type_of(&self.environment);
+                self.unify_span(bind.name.span(), &bound_typ, found_typ);
             }
         }
         // Once all variables inside the let has been unified we can quantify them

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -386,8 +386,7 @@ mod tests {
     use unify::Error::*;
     use unify::unify;
     use substitution::Substitution;
-    use base::types;
-    use base::types::{TcType, Type};
+    use base::types::{self, EmptyTypeEnv, TcType, Type};
     use tests::*;
 
 
@@ -414,7 +413,7 @@ mod tests {
                                       typ: Type::string(),
                                   }]);
         let subs = Substitution::new();
-        let env = ();
+        let env = EmptyTypeEnv;
         let mut state = State::new(&env);
         let result = unify(&subs, &mut state, &l, &r);
         assert_eq!(result,

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -386,9 +386,8 @@ mod tests {
     use unify::Error::*;
     use unify::unify;
     use substitution::Substitution;
-    use base::types::{self, EmptyTypeEnv, TcType, Type};
+    use base::types::{self, TcType, Type};
     use tests::*;
-
 
     #[test]
     fn detect_multiple_type_errors_in_single_type() {
@@ -413,7 +412,7 @@ mod tests {
                                       typ: Type::string(),
                                   }]);
         let subs = Substitution::new();
-        let env = EmptyTypeEnv;
+        let env = MockEnv;
         let mut state = State::new(&env);
         let result = unify(&subs, &mut state, &l, &r);
         assert_eq!(result,

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -48,7 +48,23 @@ pub fn typecheck(text: &str) -> Result<TcType, typecheck::Error> {
     t
 }
 
-struct MockEnv(Alias<Symbol, TcType>);
+pub struct MockEnv {
+    bool: Alias<Symbol, TcType>,
+}
+
+impl MockEnv {
+    pub fn new() -> MockEnv {
+        let interner = get_local_interner();
+        let mut interner = interner.borrow_mut();
+
+        let bool_sym = interner.symbol("Bool");
+        let bool_ty = Type::app(Type::id(bool_sym.clone()), vec![]);
+
+        MockEnv {
+            bool: Alias::new(bool_sym, vec![], bool_ty),
+        }
+    }
+}
 
 impl KindEnv for MockEnv {
     fn find_kind(&self, id: &SymbolRef) -> Option<RcKind> {
@@ -58,19 +74,22 @@ impl KindEnv for MockEnv {
         }
     }
 }
+
 impl TypeEnv for MockEnv {
     fn find_type(&self, id: &SymbolRef) -> Option<&TcType> {
         match id.as_ref() {
-            "False" | "True" => Some(&self.0.typ.as_ref().unwrap()),
+            "False" | "True" => Some(&self.bool.typ.as_ref().unwrap()),
             _ => None,
         }
     }
+
     fn find_type_info(&self, id: &SymbolRef) -> Option<&Alias<Symbol, TcType>> {
         match id.as_ref() {
-            "Bool" => Some(&self.0),
+            "Bool" => Some(&self.bool),
             _ => None,
         }
     }
+
     fn find_record(&self, _fields: &[Symbol]) -> Option<(&TcType, &TcType)> {
         None
     }
@@ -78,19 +97,16 @@ impl TypeEnv for MockEnv {
 
 impl PrimitiveEnv for MockEnv {
     fn get_bool(&self) -> &TcType {
-        self.0.typ.as_ref().unwrap()
+        self.bool.typ.as_ref().unwrap()
     }
 }
 
 pub fn typecheck_expr(text: &str) -> (ast::LExpr<TcIdent>, Result<TcType, typecheck::Error>) {
     let mut expr = parse_new(text).unwrap_or_else(|(_, err)| panic!("{}", err));
+
+    let env = MockEnv::new();
     let interner = get_local_interner();
     let mut interner = interner.borrow_mut();
-
-    let bool_sym = interner.symbol("Bool");
-    let bool = Type::<_, TcType>::app(Type::id(bool_sym.clone()), vec![]);
-
-    let env = MockEnv(Alias::new(bool_sym, vec![], bool.clone()));
     let mut tc = Typecheck::new("test".into(), &mut interner, &env);
 
     let result = tc.typecheck_expr(&mut expr);
@@ -106,13 +122,9 @@ pub fn typecheck_partial_expr(text: &str) -> (ast::LExpr<TcIdent>, Result<TcType
         Err((None, err)) => panic!("{}", err),
     };
 
+    let env = MockEnv::new();
     let interner = get_local_interner();
     let mut interner = interner.borrow_mut();
-
-    let bool_sym = interner.symbol("Bool");
-    let bool = Type::<_, TcType>::app(Type::id(bool_sym.clone()), vec![]);
-
-    let env = MockEnv(Alias::new(bool_sym, vec![], bool.clone()));
     let mut tc = Typecheck::new("test".into(), &mut interner, &env);
 
     let result = tc.typecheck_expr(&mut expr);


### PR DESCRIPTION
Done as part of working towards #50.

`env_type_of` could probably be renamed, but I think it's ok for now.

I also removed some trait object indirection, and some unused impls for the env traits.