### PR TITLE
refactor: Camelise type identifiers with acronyms/initialisms

### DIFF
--- a/base/src/symbol.rs
+++ b/base/src/symbol.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::borrow::Borrow;
 use std::ops::Deref;
 
-use ast::{AstId, DisplayEnv, IdentEnv, ASTType};
+use ast::{AstId, DisplayEnv, IdentEnv, AstType};
 
 // FIXME Don't have a double indirection (Arc + String)
 #[derive(Clone, Eq)]
@@ -351,5 +351,5 @@ impl AstId for Symbol {
     fn to_id(self) -> Symbol {
         self
     }
-    fn set_type(&mut self, _: ASTType<Self::Untyped>) {}
+    fn set_type(&mut self, _: AstType<Self::Untyped>) {}
 }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -7,10 +7,10 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use ast;
-use ast::{ASTType, DisplayEnv};
+use ast::{AstType, DisplayEnv};
 use symbol::{Symbol, SymbolRef};
 
-pub type TcType = ast::ASTType<Symbol>;
+pub type TcType = ast::AstType<Symbol>;
 pub type TcIdent = ast::TcIdent<Symbol>;
 
 /// Trait for values which contains kinded values which can be refered by name
@@ -83,7 +83,7 @@ pub fn instantiate<F>(typ: TcType, mut f: F) -> TcType
 /// `Type` such as `Type::app` and `Type::record` when constructing types as those will construct
 /// the pointer wrapper directly.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub enum Type<Id, T = ASTType<Id>> {
+pub enum Type<Id, T = AstType<Id>> {
     /// An application with multiple arguments.
     /// `Map String Int` would be represented as `App(Map, [String, Int])`
     App(T, Vec<T>),
@@ -387,10 +387,10 @@ impl<Id, T> Alias<Id, T>
     }
 }
 
-impl<Id> Alias<Id, ASTType<Id>>
+impl<Id> Alias<Id, AstType<Id>>
     where Id: Clone
 {
-    pub fn make_mut(alias: &mut Alias<Id, ASTType<Id>>) -> &mut AliasData<Id, ASTType<Id>> {
+    pub fn make_mut(alias: &mut Alias<Id, AstType<Id>>) -> &mut AliasData<Id, AstType<Id>> {
         match *Arc::make_mut(&mut alias._typ.typ) {
             Type::Alias(ref mut alias) => alias,
             _ => unreachable!(),
@@ -409,7 +409,7 @@ pub struct AliasData<Id, T> {
 }
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
-pub struct Field<Id, T = ASTType<Id>> {
+pub struct Field<Id, T = AstType<Id>> {
     pub name: Id,
     pub typ: T,
 }
@@ -578,7 +578,7 @@ impl<'a, Id, T> Iterator for ArgIterator<'a, T>
     }
 }
 
-impl<Id> ASTType<Id> {
+impl<Id> AstType<Id> {
     /// Returns the lowest level which this type contains. The level informs from where type
     /// variables where created.
     pub fn level(&self) -> u32 {

--- a/base/tests/types.rs
+++ b/base/tests/types.rs
@@ -3,7 +3,7 @@ extern crate gluon_base as base;
 use std::ops::Deref;
 
 use base::types::*;
-use base::ast::ASTType;
+use base::ast::AstType;
 
 fn type_con<I, T>(s: I, args: Vec<T>) -> Type<I, T>
     where I: Deref<Target = str>,
@@ -25,7 +25,7 @@ fn type_con<I, T>(s: I, args: Vec<T>) -> Type<I, T>
 
 #[test]
 fn show_function() {
-    let int: ASTType<&str> = Type::int();
+    let int: AstType<&str> = Type::int();
     let int_int = Type::function(vec![int.clone()], int.clone());
     assert_eq!(format!("{}", int_int),
                "Int -> Int");
@@ -39,12 +39,12 @@ fn show_function() {
 
 #[test]
 fn show_record() {
-    assert_eq!(format!("{}", Type::<&str, ASTType<&str>>::record(vec![], vec![])),
+    assert_eq!(format!("{}", Type::<&str, AstType<&str>>::record(vec![], vec![])),
                "{}");
     let typ = Type::record(vec![],
                            vec![Field {
                                     name: "x",
-                                    typ: Type::<&str, ASTType<&str>>::int(),
+                                    typ: Type::<&str, AstType<&str>>::int(),
                                 }]);
     assert_eq!(format!("{}", typ), "{ x: Int }");
 
@@ -105,7 +105,7 @@ fn show_record() {
 
 #[test]
 fn variants() {
-    let typ: ASTType<&str> = Type::variants(vec![("A", Type::function(vec![Type::int()], Type::id("A"))),
+    let typ: AstType<&str> = Type::variants(vec![("A", Type::function(vec![Type::int()], Type::id("A"))),
                                                  ("B", Type::id("A"))]);
     assert_eq!(format!("{}", typ), "| A Int | B");
 }

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -8,7 +8,7 @@ use std::slice;
 
 use gluon::vm::api::generic::A;
 use gluon::vm::api::{Getable, Pushable, Generic, CPrimitive};
-use gluon::vm::types::{VMIndex, VMInt};
+use gluon::vm::types::{VmIndex, VmInt};
 use gluon::vm::thread::{RootedThread, Thread, ThreadInternal, Status};
 
 use gluon::Compiler;
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn glu_load_script(vm: &Thread,
     }
 }
 
-pub extern "C" fn glu_call_function(thread: &Thread, arguments: VMIndex) -> Error {
+pub extern "C" fn glu_call_function(thread: &Thread, arguments: VmIndex) -> Error {
     let stack = thread.current_frame();
     match thread.call_function(stack, arguments) {
         Ok(_) => Error::Ok,
@@ -94,7 +94,7 @@ pub extern "C" fn glu_pop(vm: &Thread, n: usize) {
     }
 }
 
-pub extern "C" fn glu_push_int(vm: &Thread, int: VMInt) {
+pub extern "C" fn glu_push_int(vm: &Thread, int: VmInt) {
     Thread::push(vm, int);
 }
 
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn glu_push_function(vm: &Thread,
                                            name: &u8,
                                            len: usize,
                                            function: Function,
-                                           arguments: VMIndex)
+                                           arguments: VmIndex)
                                            -> Error {
     let s = match str::from_utf8(slice::from_raw_parts(name, len)) {
         Ok(s) => s,
@@ -145,19 +145,19 @@ pub extern "C" fn glu_push_light_userdata(vm: &Thread, data: *mut libc::c_void) 
     Thread::push(vm, data as usize);
 }
 
-pub extern "C" fn glu_get_byte(vm: &Thread, index: VMIndex, out: &mut u8) -> Error {
+pub extern "C" fn glu_get_byte(vm: &Thread, index: VmIndex, out: &mut u8) -> Error {
     get_value(vm, index, out)
 }
 
-pub extern "C" fn glu_get_int(vm: &Thread, index: VMIndex, out: &mut VMInt) -> Error {
+pub extern "C" fn glu_get_int(vm: &Thread, index: VmIndex, out: &mut VmInt) -> Error {
     get_value(vm, index, out)
 }
 
-pub extern "C" fn glu_get_float(vm: &Thread, index: VMIndex, out: &mut f64) -> Error {
+pub extern "C" fn glu_get_float(vm: &Thread, index: VmIndex, out: &mut f64) -> Error {
     get_value(vm, index, out)
 }
 
-pub extern "C" fn glu_get_bool(vm: &Thread, index: VMIndex, out: &mut i8) -> Error {
+pub extern "C" fn glu_get_bool(vm: &Thread, index: VmIndex, out: &mut i8) -> Error {
     let mut b = false;
     let err = get_value(vm, index, &mut b);
     if err == Error::Ok {
@@ -169,7 +169,7 @@ pub extern "C" fn glu_get_bool(vm: &Thread, index: VMIndex, out: &mut i8) -> Err
 /// The returned string is garbage collected and may not be valid after the string is removed from
 /// its slot in the stack
 pub unsafe extern "C" fn glu_get_string(vm: &Thread,
-                                        index: VMIndex,
+                                        index: VmIndex,
                                         out: &mut *const u8,
                                         out_len: &mut usize)
                                         -> Error {
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn glu_get_string(vm: &Thread,
 }
 
 pub extern "C" fn glu_get_light_userdata(vm: &Thread,
-                                         index: VMIndex,
+                                         index: VmIndex,
                                          out: &mut *mut libc::c_void)
                                          -> Error {
     let mut userdata = 0usize;
@@ -196,7 +196,7 @@ pub extern "C" fn glu_get_light_userdata(vm: &Thread,
     err
 }
 
-fn get_value<T>(vm: &Thread, index: VMIndex, out: &mut T) -> Error
+fn get_value<T>(vm: &Thread, index: VmIndex, out: &mut T) -> Error
     where T: for<'vm> Getable<'vm>
 {
     let stack = vm.current_frame();

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -19,7 +19,7 @@ use unify_type;
 
 use self::TypeError::*;
 
-type ErrType = ast::ASTType<String>;
+type ErrType = ast::AstType<String>;
 
 
 /// Type representing a single error when checking a type
@@ -28,15 +28,15 @@ pub enum TypeError<I> {
     /// Variable has not been defined before it was used
     UndefinedVariable(I),
     /// Attempt to call a type which is not a function
-    NotAFunction(ast::ASTType<I>),
+    NotAFunction(ast::AstType<I>),
     /// Type has not been defined before it was used
     UndefinedType(I),
     /// Type were expected to have a certain field
-    UndefinedField(ast::ASTType<I>, I),
+    UndefinedField(ast::AstType<I>, I),
     /// Constructor type was found in a pattern but did not have the expected number of arguments
-    PatternError(ast::ASTType<I>, usize),
+    PatternError(ast::AstType<I>, usize),
     /// Errors found when trying to unify two types
-    Unification(ast::ASTType<I>, ast::ASTType<I>, Vec<unify_type::Error<I>>),
+    Unification(ast::AstType<I>, ast::AstType<I>, Vec<unify_type::Error<I>>),
     /// Error were found when trying to unify the kinds of two types
     KindError(kindcheck::Error<I>),
     /// Errors found during renaming (overload resolution)
@@ -44,7 +44,7 @@ pub enum TypeError<I> {
     /// Multiple types were declared with the same name in the same expression
     DuplicateTypeDefinition(I),
     /// Type is not a type which has any fields
-    InvalidFieldAccess(ast::ASTType<I>),
+    InvalidFieldAccess(ast::AstType<I>),
     /// Expected to find a record with the following fields
     UndefinedRecord {
         fields: Vec<I>,

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use base::ast::ASTType;
+use base::ast::AstType;
 use base::types::{self, TcType, Type, TypeVariable, TypeEnv, merge};
 use base::symbol::{Symbol, SymbolRef};
 use base::instantiate;
@@ -9,7 +9,7 @@ use unify;
 use unify::{Error as UnifyError, Unifier, Unifiable};
 use substitution::{Variable, Substitutable};
 
-pub type Error<I> = UnifyError<ASTType<I>, TypeError<I>>;
+pub type Error<I> = UnifyError<AstType<I>, TypeError<I>>;
 
 pub struct State<'a> {
     env: &'a (TypeEnv + 'a),
@@ -72,14 +72,14 @@ impl Variable for TypeVariable {
     }
 }
 
-impl<I> Substitutable for ASTType<I> {
+impl<I> Substitutable for AstType<I> {
     type Variable = TypeVariable;
 
-    fn new(id: u32) -> ASTType<I> {
+    fn new(id: u32) -> AstType<I> {
         Type::variable(TypeVariable::new(id))
     }
 
-    fn from_variable(var: TypeVariable) -> ASTType<I> {
+    fn from_variable(var: TypeVariable) -> AstType<I> {
         Type::variable(var)
     }
 
@@ -91,7 +91,7 @@ impl<I> Substitutable for ASTType<I> {
     }
 
     fn traverse<F>(&self, f: &mut F)
-        where F: types::Walker<ASTType<I>>
+        where F: types::Walker<AstType<I>>
     {
         types::walk_type_(self, f)
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -188,10 +188,10 @@ impl<'s, I, Id, F> ParserEnv<I, F>
             .parse_state(input)
     }
 
-    fn ident_type(&'s self) -> LanguageParser<'s, I, F, ASTType<Id::Untyped>> {
+    fn ident_type(&'s self) -> LanguageParser<'s, I, F, AstType<Id::Untyped>> {
         self.parser(ParserEnv::<I, F>::parse_ident_type)
     }
-    fn parse_ident_type(&self, input: I) -> ParseResult<ASTType<Id::Untyped>, I> {
+    fn parse_ident_type(&self, input: I) -> ParseResult<AstType<Id::Untyped>, I> {
         try(self.parser(ParserEnv::<I, F>::parse_ident2))
             .map(|(s, typ)| {
                 debug!("Id: {:?}", s);
@@ -223,14 +223,14 @@ impl<'s, I, Id, F> ParserEnv<I, F>
 
     match_parser! { doc_comment, DocComment -> String }
 
-    fn typ(&'s self) -> LanguageParser<'s, I, F, ASTType<Id::Untyped>> {
+    fn typ(&'s self) -> LanguageParser<'s, I, F, AstType<Id::Untyped>> {
         self.parser(ParserEnv::<I, F>::parse_type)
     }
 
     fn parse_adt(&self,
-                 return_type: &ASTType<Id::Untyped>,
+                 return_type: &AstType<Id::Untyped>,
                  input: I)
-                 -> ParseResult<ASTType<Id::Untyped>, I> {
+                 -> ParseResult<AstType<Id::Untyped>, I> {
         let variant = (token(Token::Pipe),
                        self.ident_u(),
                        many(self.parser(ParserEnv::<I, F>::type_arg)))
@@ -240,7 +240,7 @@ impl<'s, I, Id, F> ParserEnv<I, F>
             .parse_state(input)
     }
 
-    fn parse_type(&self, input: I) -> ParseResult<ASTType<Id::Untyped>, I> {
+    fn parse_type(&self, input: I) -> ParseResult<AstType<Id::Untyped>, I> {
         (many1(self.parser(ParserEnv::<I, F>::type_arg)),
          optional(token(Token::RightArrow).with(self.typ())))
             .map(|(mut arg, ret): (Vec<_>, _)| {
@@ -259,7 +259,7 @@ impl<'s, I, Id, F> ParserEnv<I, F>
             .parse_state(input)
     }
 
-    fn record_type(&self, input: I) -> ParseResult<ASTType<Id::Untyped>, I> {
+    fn record_type(&self, input: I) -> ParseResult<AstType<Id::Untyped>, I> {
         let field = self.parser(ParserEnv::<I, F>::parse_ident2)
             .then(|(id, typ)| {
                 parser(move |input| {
@@ -306,8 +306,8 @@ impl<'s, I, Id, F> ParserEnv<I, F>
             .parse_state(input)
     }
 
-    fn type_arg(&self, input: I) -> ParseResult<ASTType<Id::Untyped>, I> {
-        choice::<[&mut Parser<Input = I, Output = ASTType<Id::Untyped>>; 3],
+    fn type_arg(&self, input: I) -> ParseResult<AstType<Id::Untyped>, I> {
+        choice::<[&mut Parser<Input = I, Output = AstType<Id::Untyped>>; 3],
                  _>([&mut self.parser(ParserEnv::<I, F>::record_type),
                      &mut between(token(Token::Open(Delimiter::Paren)),
                                   token(Token::Close(Delimiter::Paren)),

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -38,13 +38,13 @@ fn let_a(s: &str, args: &[&str], e: PExpr, b: PExpr) -> PExpr {
 fn id(s: &str) -> PExpr {
     no_loc(Expr::Identifier(intern(s)))
 }
-fn field(s: &str, typ: ASTType<String>) -> Field<String> {
+fn field(s: &str, typ: AstType<String>) -> Field<String> {
     Field {
         name: intern(s),
         typ: typ,
     }
 }
-fn typ(s: &str) -> ASTType<String> {
+fn typ(s: &str) -> AstType<String> {
     assert!(s.len() != 0);
     let is_var = s.chars().next().unwrap().is_lowercase();
     match s.parse() {
@@ -53,7 +53,7 @@ fn typ(s: &str) -> ASTType<String> {
         Err(()) => Type::id(intern(s)),
     }
 }
-fn generic_ty(s: &str) -> ASTType<String> {
+fn generic_ty(s: &str) -> AstType<String> {
     Type::generic(generic(s))
 }
 fn generic(s: &str) -> Generic<String> {
@@ -87,7 +87,7 @@ fn lambda(name: &str, args: Vec<String>, body: PExpr) -> PExpr {
     }))
 }
 
-fn type_decl(name: String, args: Vec<Generic<String>>, typ: ASTType<String>, body: PExpr) -> PExpr {
+fn type_decl(name: String, args: Vec<Generic<String>>, typ: AstType<String>, body: PExpr) -> PExpr {
     type_decls(vec![TypeBinding {
                         comment: None,
                         name: name.clone(),
@@ -103,7 +103,7 @@ fn type_decls(binds: Vec<TypeBinding<String>>, body: PExpr) -> PExpr {
 fn record(fields: Vec<(String, Option<PExpr>)>) -> PExpr {
     record_a(Vec::new(), fields)
 }
-fn record_a(types: Vec<(String, Option<ASTType<String>>)>,
+fn record_a(types: Vec<(String, Option<AstType<String>>)>,
             fields: Vec<(String, Option<PExpr>)>)
             -> PExpr {
     no_loc(Expr::Record {

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,14 +9,14 @@ use vm::gc::{Gc, Traverseable};
 use vm::types::*;
 use vm::thread::ThreadInternal;
 use vm::thread::{Thread, Status, RootStr};
-use vm::api::{Array, Generic, VMType, Getable, Pushable, IO, WithVM, Userdata, primitive};
+use vm::api::{Array, Generic, VmType, Getable, Pushable, IO, WithVM, Userdata, primitive};
 use vm::api::generic::{A, B};
 
 use vm::internal::Value;
 
 use super::Compiler;
 
-fn print_int(i: VMInt) -> IO<()> {
+fn print_int(i: VmInt) -> IO<()> {
     print!("{}", i);
     IO::Value(())
 }
@@ -34,7 +34,7 @@ impl fmt::Debug for GluonFile {
     }
 }
 
-impl VMType for GluonFile {
+impl VmType for GluonFile {
     type Type = GluonFile;
 }
 
@@ -204,12 +204,12 @@ pub fn load(vm: &Thread) -> Result<()> {
         PushInt(0),     // [f, m_ret, ()]   Add a dummy argument ()
         TailCall(2),    // [f_ret]          Call f m_ret ()
     ];
-    let io_flat_map_type = <fn (fn (A) -> IO<B>, IO<A>) -> IO<B> as VMType>::make_type(vm);
+    let io_flat_map_type = <fn (fn (A) -> IO<B>, IO<A>) -> IO<B> as VmType>::make_type(vm);
     vm.add_bytecode("io_flat_map", io_flat_map_type, 3, io_flat_map);
 
 
     vm.add_bytecode("io_pure",
-                    <fn(A) -> IO<A> as VMType>::make_type(vm),
+                    <fn(A) -> IO<A> as VmType>::make_type(vm),
                     2,
                     vec![Pop(1)]);
     // IO functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@ use base::metadata::Metadata;
 
 use vm::Variants;
 use vm::api::generic::A;
-use vm::api::{Getable, VMType, Generic, IO};
-use vm::Error as VMError;
+use vm::api::{Getable, VmType, Generic, IO};
+use vm::Error as VmError;
 use vm::compiler::CompiledFunction;
 use vm::thread::{RootedValue, ThreadInternal};
 use vm::internal::ClosureDataDef;
@@ -464,20 +464,20 @@ impl Compiler {
     /// Compiles and runs the expression in `expr_str`. If successful the value from running the
     /// expression is returned
     pub fn run_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<(T, TcType)>
-        where T: Getable<'vm> + VMType
+        where T: Getable<'vm> + VmType
     {
         let expected = T::make_type(vm);
         let (value, actual) = try!(self.run_expr_(vm, name, expr_str, Some(&expected)));
         unsafe {
             match T::from_value(vm, Variants::new(&value)) {
                 Some(value) => Ok((value, actual)),
-                None => Err(Error::from(VMError::WrongType(expected, actual))),
+                None => Err(Error::from(VmError::WrongType(expected, actual))),
             }
         }
     }
 
     pub fn run_io_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<(T, TcType)>
-        where T: Getable<'vm> + VMType,
+        where T: Getable<'vm> + VmType,
               T::Type: Sized
     {
         let expected = IO::<T>::make_type(vm);
@@ -485,7 +485,7 @@ impl Compiler {
         unsafe {
             match T::from_value(vm, Variants::new(&value)) {
                 Some(value) => Ok((value, actual)),
-                None => Err(Error::from(VMError::WrongType(expected, actual))),
+                None => Err(Error::from(VmError::WrongType(expected, actual))),
             }
         }
     }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -8,7 +8,7 @@ use self::rustyline::error::ReadlineError;
 
 use base::ast::Typed;
 use base::types::Kind;
-use vm::api::{IO, Function, WithVM, VMType, Userdata};
+use vm::api::{IO, Function, WithVM, VmType, Userdata};
 use vm::gc::{Gc, Traverseable};
 use vm::thread::{Thread, RootStr};
 
@@ -92,7 +92,7 @@ impl fmt::Debug for Editor {
     }
 }
 
-impl VMType for Editor {
+impl VmType for Editor {
     type Type = Editor;
 }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -2,9 +2,9 @@ extern crate env_logger;
 extern crate gluon;
 
 use gluon::base::types::Type;
-use gluon::vm::api::{self, VMType, FunctionRef};
+use gluon::vm::api::{self, VmType, FunctionRef};
 use gluon::vm::thread::{RootedThread, Thread, Traverseable, Root, RootStr};
-use gluon::vm::types::VMInt;
+use gluon::vm::types::VmInt;
 use gluon::Compiler;
 use gluon::import::Import;
 
@@ -36,7 +36,7 @@ let mul : Float -> Float -> Float = \x y -> x #Float* y in mul
     load_script(&mut vm, "add10", &add10).unwrap_or_else(|err| panic!("{}", err));
     load_script(&mut vm, "mul", &mul).unwrap_or_else(|err| panic!("{}", err));
     {
-        let mut f: FunctionRef<fn(VMInt) -> VMInt> = vm.get_global("add10")
+        let mut f: FunctionRef<fn(VmInt) -> VmInt> = vm.get_global("add10")
                                                     .unwrap();
         let result = f.call(2).unwrap();
         assert_eq!(result, 12);
@@ -51,9 +51,9 @@ fn root_data() {
     let _ = ::env_logger::init();
 
     #[derive(Debug)]
-    struct Test(VMInt);
+    struct Test(VmInt);
     impl Traverseable for Test { }
-    impl VMType for Test {
+    impl VmType for Test {
         type Type = Test;
     }
 
@@ -61,7 +61,7 @@ fn root_data() {
 \x -> test x 1
 "#;
     let vm = make_vm();
-    fn test(r: Root<Test>, i: VMInt) -> VMInt {
+    fn test(r: Root<Test>, i: VmInt) -> VmInt {
         r.0 + i
     }
     vm.register_type::<Test>("Test", &[])
@@ -72,7 +72,7 @@ fn root_data() {
       })
       .unwrap();
     load_script(&vm, "script_fn", expr).unwrap_or_else(|err| panic!("{}", err));
-    let mut script_fn: FunctionRef<fn(api::Userdata<Test>) -> VMInt> = vm.get_global("script_fn").unwrap();
+    let mut script_fn: FunctionRef<fn(api::Userdata<Test>) -> VmInt> = vm.get_global("script_fn").unwrap();
     let result = script_fn.call(api::Userdata(Test(123)))
                           .unwrap();
     assert_eq!(result, 124);

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -1,12 +1,12 @@
 extern crate gluon;
 use gluon::new_vm;
 use gluon::vm::gc::{Gc, Traverseable};
-use gluon::vm::api::{Pushable, VMType};
+use gluon::vm::api::{Pushable, VmType};
 
 #[derive(Debug)]
 struct Test;
 
-impl VMType for Test {
+impl VmType for Test {
     type Type = Test;
 }
 

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::sync::Mutex;
 
 use gluon::new_vm;
-use gluon::vm::api::VMType;
+use gluon::vm::api::VmType;
 use gluon::vm::gc::Traverseable;
 
 struct Test<'vm>(Mutex<&'vm str>);
@@ -15,7 +15,7 @@ impl<'vm> fmt::Debug for Test<'vm> {
 }
 
 impl<'vm> Traverseable for Test<'vm> { }
-impl<'vm> VMType for Test<'vm> {
+impl<'vm> VmType for Test<'vm> {
     type Type = Test<'static>;
 }
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -2,7 +2,7 @@ extern crate env_logger;
 extern crate gluon;
 
 use gluon::vm::api::generic::A;
-use gluon::vm::api::{FunctionRef, Generic, Getable, VMType, OpaqueValue};
+use gluon::vm::api::{FunctionRef, Generic, Getable, VmType, OpaqueValue};
 use gluon::vm::thread::{RootedThread, Thread, ThreadInternal};
 use gluon::vm::internal::Value;
 use gluon::vm::internal::Value::{Float, Int};
@@ -18,7 +18,7 @@ pub fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<
 }
 
 pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
-    where T: Getable<'vm> + VMType
+    where T: Getable<'vm> + VmType
 {
     Compiler::new()
         .implicit_prelude(implicit_prelude)
@@ -27,7 +27,7 @@ pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
 }
 
 pub fn run_expr<'vm, T>(vm: &'vm Thread, s: &str) -> T
-    where T: Getable<'vm> + VMType
+    where T: Getable<'vm> + VmType
 {
     run_expr_(vm, s, false)
 }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -4,9 +4,9 @@ use std::collections::VecDeque;
 
 use base::types::{TcType, Type};
 
-use {Error, Result as VMResult};
+use {Error, Result as VmResult};
 use api::record::{Record, HList};
-use api::{Generic, Userdata, VMType, primitive, WithVM, Function, Pushable};
+use api::{Generic, Userdata, VmType, primitive, WithVM, Function, Pushable};
 use api::generic::A;
 use gc::{Traverseable, Gc, GcPtr};
 use vm::{Thread, RootedThread, Status};
@@ -70,7 +70,7 @@ impl<T> Receiver<T> {
     }
 }
 
-impl<T: VMType> VMType for Sender<T>
+impl<T: VmType> VmType for Sender<T>
     where T::Type: Sized
 {
     type Type = Sender<T::Type>;
@@ -80,7 +80,7 @@ impl<T: VMType> VMType for Sender<T>
     }
 }
 
-impl<T: VMType> VMType for Receiver<T>
+impl<T: VmType> VmType for Receiver<T>
     where T::Type: Sized
 {
     type Type = Receiver<T::Type>;
@@ -177,7 +177,7 @@ fn f2<A, B, R>(f: fn(A, B) -> R) -> fn(A, B) -> R {
     f
 }
 
-pub fn load(vm: &Thread) -> VMResult<()> {
+pub fn load(vm: &Thread) -> VmResult<()> {
     let _ = vm.register_type::<Sender<A>>("Sender", &["a"]);
     let _ = vm.register_type::<Receiver<A>>("Receiver", &["a"]);
     try!(vm.define_global("channel", f1(channel)));

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use base::ast::{AstId, DisplayEnv, IdentEnv, ASTType};
+use base::ast::{AstId, DisplayEnv, IdentEnv, AstType};
 
 use gc::{GcPtr, Gc, Traverseable};
 use array::Str;
@@ -128,5 +128,5 @@ impl AstId for InternedStr {
     fn to_id(self) -> InternedStr {
         self
     }
-    fn set_type(&mut self, _: ASTType<Self::Untyped>) {}
+    fn set_type(&mut self, _: AstType<Self::Untyped>) {}
 }

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use base::types;
 use base::types::{Type, TcType};
 use gc::{Gc, Traverseable};
-use api::{Userdata, VMType, Pushable};
+use api::{Userdata, VmType, Pushable};
 use api::generic::A;
 use vm::{Status, Thread};
 use Result;
@@ -40,8 +40,8 @@ impl<T> Traverseable for Lazy<T> {
     }
 }
 
-impl<T> VMType for Lazy<T>
-    where T: VMType,
+impl<T> VmType for Lazy<T>
+    where T: VmType,
           T::Type: Sized
 {
     type Type = Lazy<T::Type>;

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -10,14 +10,14 @@ use Result;
 use vm::{Thread, Status};
 use value::{Value, ValueArray};
 use thread::ThreadInternal;
-use types::VMInt;
+use types::VmInt;
 
-fn array_length(array: Array<generic::A>) -> VMInt {
-    array.len() as VMInt
+fn array_length(array: Array<generic::A>) -> VmInt {
+    array.len() as VmInt
 }
 
 fn array_index<'vm>(array: Array<'vm, Generic<generic::A>>,
-                    index: VMInt)
+                    index: VmInt)
                     -> MaybeError<Generic<generic::A>, String> {
     match array.get(index) {
         Some(value) => MaybeError::Ok(value),
@@ -136,7 +136,7 @@ fn trace(a: Generic<A>) {
     println!("{:?}", a.0);
 }
 
-fn show_int(i: VMInt) -> String {
+fn show_int(i: VmInt) -> String {
     format!("{}", i)
 }
 
@@ -221,21 +221,21 @@ pub fn load(vm: &Thread) -> Result<()> {
     )));
     try!(vm.define_global("int",
                           record!(
-        min_value => VMInt::min_value(),
-        max_value => VMInt::max_value(),
-        count_ones => primitive!(1 VMInt::count_ones),
-        rotate_left => primitive!(2 VMInt::rotate_left),
-        rotate_right => primitive!(2 VMInt::rotate_right),
-        swap_bytes => primitive!(1 VMInt::swap_bytes),
-        from_be => primitive!(1 VMInt::from_be),
-        from_le => primitive!(1 VMInt::from_le),
-        to_be => primitive!(1 VMInt::to_be),
-        to_le => primitive!(1 VMInt::to_le),
-        pow => primitive!(2 VMInt::pow),
-        abs => primitive!(1 VMInt::abs),
-        signum => primitive!(1 VMInt::signum),
-        is_positive => primitive!(1 VMInt::is_positive),
-        is_negative => primitive!(1 VMInt::is_negative)
+        min_value => VmInt::min_value(),
+        max_value => VmInt::max_value(),
+        count_ones => primitive!(1 VmInt::count_ones),
+        rotate_left => primitive!(2 VmInt::rotate_left),
+        rotate_right => primitive!(2 VmInt::rotate_right),
+        swap_bytes => primitive!(1 VmInt::swap_bytes),
+        from_be => primitive!(1 VmInt::from_be),
+        from_le => primitive!(1 VmInt::from_le),
+        to_be => primitive!(1 VmInt::to_be),
+        to_le => primitive!(1 VmInt::to_le),
+        pow => primitive!(2 VmInt::pow),
+        abs => primitive!(1 VmInt::abs),
+        signum => primitive!(1 VmInt::signum),
+        is_positive => primitive!(1 VmInt::is_positive),
+        is_negative => primitive!(1 VmInt::is_negative)
     )));
     try!(vm.define_global("array",
                           record!(

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -9,7 +9,7 @@ use stack::Stack;
 use vm::{Thread, Status};
 use thread::ThreadInternal;
 use value::Value;
-use api::{MaybeError, Generic, Pushable, Userdata, VMType, WithVM};
+use api::{MaybeError, Generic, Pushable, Userdata, VmType, WithVM};
 use api::generic::A;
 
 struct Reference<T> {
@@ -30,8 +30,8 @@ impl<T> Traverseable for Reference<T> {
     }
 }
 
-impl<T> VMType for Reference<T>
-    where T: VMType,
+impl<T> VmType for Reference<T>
+    where T: VmType,
           T::Type: Sized
 {
     type Type = Reference<T::Type>;
@@ -45,7 +45,7 @@ impl<T> VMType for Reference<T>
 }
 
 impl<'vm, T> Pushable<'vm> for Reference<T>
-    where T: Any + Send + Sync + VMType,
+    where T: Any + Send + Sync + VmType,
           T::Type: Sized
 {
     fn push(self, vm: &'vm Thread, stack: &mut Stack) -> Status {

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -5,9 +5,9 @@ use base::types::{Alias, KindEnv, TypeEnv, TcType, Type};
 
 pub use self::Instruction::*;
 
-pub type VMIndex = u32;
-pub type VMTag = u32;
-pub type VMInt = isize;
+pub type VmIndex = u32;
+pub type VmTag = u32;
+pub type VmInt = isize;
 
 /// Enum which represent the instructions executed by the virtual machine.
 ///
@@ -22,68 +22,68 @@ pub enum Instruction {
     PushFloat(f64),
     /// Push a string to the stack by loading the string at `index` in the currently executing
     /// function
-    PushString(VMIndex),
+    PushString(VmIndex),
     /// Push a variable to the stack by loading the upvariable at `index` from the currently
     /// executing function
-    PushUpVar(VMIndex),
+    PushUpVar(VmIndex),
     /// Push the value at `index`
-    Push(VMIndex),
+    Push(VmIndex),
     /// Push the value at `index`
-    PushGlobal(VMIndex),
+    PushGlobal(VmIndex),
     /// Call a function by passing it `args` number of arguments. The function is at the index in
     /// the stack just before the arguments. After the call is all arguments are removed and the
     /// function is replaced by the result of the call.
-    Call(VMIndex),
+    Call(VmIndex),
     /// Tailcalls a function, removing the current stack frame before calling it.
     /// See `Call`.
-    TailCall(VMIndex),
+    TailCall(VmIndex),
     /// Constructs a data value tagged by `tag` by taking the top `args` values of the stack.
     Construct {
         /// The tag of the data
-        tag: VMIndex,
+        tag: VmIndex,
         /// How many arguments that is taken from the stack to construct the data.
-        args: VMIndex,
+        args: VmIndex,
     },
     /// Constructs an array containing `args` values.
-    ConstructArray(VMIndex),
+    ConstructArray(VmIndex),
     /// Retrieves the field at `index` of an object at the top of the stack. The result of the
     /// field access replaces the object on the stack.
-    GetField(VMIndex),
+    GetField(VmIndex),
     /// Splits a object, pushing all contained values to the stack.
     Split,
     /// Tests if the value at the top of the stack is tagged with `tag`. Pushes `True` if the tag
     /// matches, otherwise `False`
-    TestTag(VMTag),
+    TestTag(VmTag),
     /// Jumps to the instruction at `index` in the currently executing function.
-    Jump(VMIndex),
+    Jump(VmIndex),
     /// Jumps to the instruction at `index` in the currently executing function if `True` is at the
     /// top of the stack and pops that value.
-    CJump(VMIndex),
+    CJump(VmIndex),
     /// Pops the top `n` values from the stack.
-    Pop(VMIndex),
+    Pop(VmIndex),
     /// Pops the top value from the stack, then pops `n` more values, finally the first value is
     /// pushed back to the stack.
-    Slide(VMIndex),
+    Slide(VmIndex),
 
     /// Creates a closure with the function at `function_index` of the currently executing function
     /// and `upvars` upvariables popped from the top of the stack.
     MakeClosure {
         /// The index in the currently executing function which the function data is located at
-        function_index: VMIndex,
+        function_index: VmIndex,
         /// How many upvariables the closure contains
-        upvars: VMIndex,
+        upvars: VmIndex,
     },
     /// Creates a closure with the function at `function_index` of the currently executing
     /// function. The closure has room for `upvars` upvariables but these are not filled until the
     /// matching call to `ClosureClosure` is executed.
     NewClosure {
         /// The index in the currently executing function which the function data is located at
-        function_index: VMIndex,
+        function_index: VmIndex,
         /// How many upvariables the closure contains
-        upvars: VMIndex,
+        upvars: VmIndex,
     },
     /// Fills the previously allocated closure with `n` upvariables.
-    CloseClosure(VMIndex),
+    CloseClosure(VmIndex),
 
     AddInt,
     SubtractInt,

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -100,7 +100,7 @@ unsafe impl DataDef for ClosureInitDef {
 #[derive(Debug)]
 pub struct BytecodeFunction {
     pub name: Symbol,
-    pub args: VMIndex,
+    pub args: VmIndex,
     pub instructions: Vec<Instruction>,
     pub inner_functions: Vec<GcPtr<BytecodeFunction>>,
     pub strings: Vec<InternedStr>,
@@ -115,7 +115,7 @@ impl Traverseable for BytecodeFunction {
 }
 
 pub struct DataStruct {
-    pub tag: VMTag,
+    pub tag: VmTag,
     pub fields: Array<Value>,
 }
 
@@ -133,7 +133,7 @@ impl PartialEq for DataStruct {
 
 /// Definition for data values in the VM
 pub struct Def<'b> {
-    pub tag: VMTag,
+    pub tag: VmTag,
     pub elems: &'b [Value],
 }
 unsafe impl<'b> DataDef for Def<'b> {
@@ -161,10 +161,10 @@ impl<'b> Traverseable for Def<'b> {
 #[derive(Copy, Clone, PartialEq)]
 pub enum Value {
     Byte(u8),
-    Int(VMInt),
+    Int(VmInt),
     Float(f64),
     String(GcPtr<Str>),
-    Tag(VMTag),
+    Tag(VmTag),
     Data(GcPtr<DataStruct>),
     Array(GcPtr<ValueArray>),
     Function(GcPtr<ExternFunction>),
@@ -204,7 +204,7 @@ impl Callable {
         }
     }
 
-    pub fn args(&self) -> VMIndex {
+    pub fn args(&self) -> VmIndex {
         match *self {
             Callable::Closure(ref closure) => closure.function.args,
             Callable::Extern(ref ext) => ext.args,
@@ -360,7 +360,7 @@ impl fmt::Debug for Value {
 
 pub struct ExternFunction {
     pub id: Symbol,
-    pub args: VMIndex,
+    pub args: VmIndex,
     pub function: Box<Fn(&Thread) -> Status + Send + Sync>,
 }
 
@@ -438,7 +438,7 @@ macro_rules! impl_repr {
 
 impl_repr! {
     u8, Repr::Byte,
-    VMInt, Repr::Int,
+    VmInt, Repr::Int,
     f64, Repr::Float,
     GcPtr<Str>, Repr::String,
     GcPtr<ValueArray>, Repr::Array,
@@ -474,7 +474,7 @@ macro_rules! on_array {
             unsafe {
                 match array.repr() {
                     Repr::Byte => $f(array.unsafe_array::<u8>()),
-                    Repr::Int => $f(array.unsafe_array::<VMInt>()),
+                    Repr::Int => $f(array.unsafe_array::<VmInt>()),
                     Repr::Float => $f(array.unsafe_array::<f64>()),
                     Repr::String => $f(array.unsafe_array::<GcPtr<Str>>()),
                     Repr::Array => $f(array.unsafe_array::<GcPtr<ValueArray>>()),


### PR DESCRIPTION
Fixes #90 

refactored type identifiers are

```Rust
ASTType
VMIndex
VMInt
VMType
VMError
VMTag
VMFunction
VMResult
VMEnv
GlobalVMState
```

