### PR TITLE
fix(check): Don't generalize variables from an outer scope ...

### DIFF
--- a/check/src/substitution.rs
+++ b/check/src/substitution.rs
@@ -294,6 +294,10 @@ impl<T: Substitutable + PartialEq + Clone> Substitution<T> {
     pub fn union(&self, id: &T::Variable, typ: &T) -> Result<(), ()>
         where T::Variable: Clone
     {
+        // Nothing needs to be done if both are the same variable already (also prevents the occurs check from failing)
+        if typ.get_var().map_or(false, |other| other.get_id() == id.get_id()) {
+            return Ok(());
+        }
         if occurs(typ, self, id) {
             return Err(());
         }

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -133,7 +133,6 @@ impl<'e, S, T> Unifier<S, T> for Unify<'e, T, T::Error>
         // `l` and `r` must have the same type, if one is a variable that variable is
         // unified with whatever the other type is
         let result = match (l.get_var(), r.get_var()) {
-            (Some(l), Some(r)) if l.get_id() == r.get_id() => Ok(None),
             (_, Some(r)) => {
                 match subs.union(r, l) {
                     Ok(()) => Ok(None),

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -294,3 +294,17 @@ let g x: A a -> () = x
 
     assert_unify_err!(result, Other(SelfRecursive(..)));
 }
+
+#[test]
+fn declared_generic_variables_may_not_make_outer_bindings_more_general() {
+    let _ = ::env_logger::init();
+    let text = r#"
+let make m =
+    let m2: m = m
+    m
+
+make
+"#;
+    let result = support::typecheck(text);
+    assert!(result.is_err());
+}

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -698,13 +698,12 @@ in \(<) ->
         | Cons y ys -> if x < y
                        then Cons x xs
                        else Cons y (insert x ys)
-    let ret : { empty: SortedList a, insert: a -> SortedList a -> SortedList a }
-        = { empty, insert }
+    let ret = { empty, insert }
     ret
 ";
     let result = support::typecheck(text);
 
-    assert!(result.is_ok());
+    assert!(result.is_ok(), "{}", result.unwrap_err());
 }
 
 #[test]
@@ -826,4 +825,19 @@ in r1"#;
                                           }])));
 
     assert_eq!(result, expected);
+}
+
+#[test]
+fn scoped_generic_variable() {
+    let _ = ::env_logger::init();
+    let text = r#"
+let any x = any x
+let make m: m -> { test: m, test2: m } =
+    let m2: m = any ()
+    { test = m, test2 = m2 }
+
+make
+"#;
+    let result = support::typecheck(text);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ impl Compiler {
             let env = vm.get_env();
             let name = Name::new(filename);
             let name = NameBuf::from(name.module());
-            let symbols = SymbolModule::new(StdString::from(name.as_ref()), &mut self.symbols);
+            let symbols = SymbolModule::new(StdString::from(AsRef::<str>::as_ref(&name)), &mut self.symbols);
             let mut compiler = Compiler::new(&*env, vm.global_env(), symbols);
             compiler.compile_expr(&expr)
         };

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -66,7 +66,7 @@ let monoid_Float_Mul = {
 let make_Monoid m =
     let { append, empty } = m
 
-    let (<>) : m -> m -> m = append
+    let (<>) /* : m -> m -> m */ = append
 
     { append, empty, (<>) }
 
@@ -310,9 +310,9 @@ let make_Category cat =
     let { id, compose } = cat
 
     /// Right-to-left composition. Alias for `compose`.
-    let (<<) : cat b c -> cat a b -> cat a c = compose
+    let (<<) /* : cat b c -> cat a b -> cat a c */ = compose
     /// Left-to-right composition. Alias for `compose`, but with the arguments flipped.
-    let (>>) f g : cat a b -> cat b c -> cat a c = compose g f
+    let (>>) f g /* : cat a b -> cat b c -> cat a c */ = compose g f
 
     { id, compose, (<<), (>>) }
 
@@ -433,11 +433,11 @@ let applicative_IO : Applicative IO =
 let make_Applicative app =
     let { functor, apply, pure } = app
 
-    let (<*>) : app (a -> b) -> app a -> app b = apply
-    let (<*) l r : app a -> app b -> app a = functor.map const l <*> r
-    let (*>) l r : app a -> app b -> app b = functor.map (const id) l <*> r
-    let map2 f a b : (a -> b -> c) -> app a -> app b -> app c = (functor.map f a) <*> b
-    let map3 f a b c : (a -> b -> c -> d) -> app a -> app b -> app c -> app d = (functor.map f a) <*> b <*> c
+    let (<*>) /* : app (a -> b) -> app a -> app b */ = apply
+    let (<*) l r /* : app a -> app b -> app a */ = functor.map const l <*> r
+    let (*>) l r /* : app a -> app b -> app b */ = functor.map (const id) l <*> r
+    let map2 f a b /* : (a -> b -> c) -> app a -> app b -> app c */ = (functor.map f a) <*> b
+    let map3 f a b c /* : (a -> b -> c -> d) -> app a -> app b -> app c -> app d */ = (functor.map f a) <*> b <*> c
 
     { functor, apply, pure, (<*>), (<*), (*>), map2, map3 }
 
@@ -466,12 +466,12 @@ let make_Alternative f =
     let { applicative, or, empty } = f
     let { functor, (<*>), pure } = make_Applicative applicative
 
-    let (<|>) : f a -> f a -> f a = or
-    let many x : f a -> f (List a) =
+    let (<|>) /* : f a -> f a -> f a */ = or
+    let many x /* : f a -> f (List a) */ =
         let many_v _ = some_v () <|> pure Nil
         and some_v _ = functor.map (\h l -> Cons h l) x <*> many_v ()
         many_v ()
-    let some x : f a -> f (List a) =
+    let some x  /* : f a -> f (List a) */ =
         let many_v _ = some_v () <|> pure Nil
         and some_v _ = functor.map (\h l -> Cons h l) x <*> many_v ()
         some_v ()
@@ -516,10 +516,10 @@ let make_Monad m =
     let { (*>), pure } = make_Applicative applicative
     let { id } = category_Function
 
-    let (=<<) : (a -> m b) -> m a -> m b = flat_map
-    let (>>=) : m a -> (a -> m b) -> m b = flip flat_map
-    let join mm : m (m a) -> m a = mm >>= id
-    let forM_ xs f : List a -> (a -> m b) -> m () =
+    let (=<<) /* : (a -> m b) -> m a -> m b */ = flat_map
+    let (>>=) /* : m a -> (a -> m b) -> m b */ = flip flat_map
+    let join mm /* : m (m a) -> m a */ = mm >>= id
+    let forM_ xs f /* : List a -> (a -> m b) -> m () */ =
         match xs with
             | Cons y ys -> f y *> forM_ ys f
             | Nil -> pure ()

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -21,7 +21,10 @@ fn read_file() {
             assert (array.index bytes 1 #Byte== 112b) // p
             pure (array.index bytes 8)
         "#;
-    let (result, _) = Compiler::new().run_io_expr::<u8>(&thread, "<top>", text).unwrap();
+    let result = Compiler::new().run_io_expr::<u8>(&thread, "<top>", text);
 
-    assert_eq!(result, b']');
+    match result {
+        Ok((value, _)) => assert_eq!(value, b']'),
+        Err(err) => assert!(false, "{}", err),
+    }
 }


### PR DESCRIPTION
... when merging with a type signature

This commit tracks all type variables introduced in type signatures and uses this information to emit an error when a variable from a signature is matched to a variable from an outer scope.

Fixes #77