### PR TITLE
refactor(vm): Remove the need for the api::Userdata wrapper

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -28,6 +28,8 @@ fn print(s: RootStr) -> IO<()> {
 
 struct GluonFile(Mutex<File>);
 
+impl Userdata for GluonFile { }
+
 impl fmt::Debug for GluonFile {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "File")
@@ -42,9 +44,9 @@ impl Traverseable for GluonFile {
     fn traverse(&self, _: &mut Gc) {}
 }
 
-fn open_file(s: &str) -> IO<Userdata<GluonFile>> {
+fn open_file(s: &str) -> IO<GluonFile> {
     match File::open(s) {
-        Ok(f) => IO::Value(Userdata(GluonFile(Mutex::new(f)))),
+        Ok(f) => IO::Value(GluonFile(Mutex::new(f))),
         Err(err) => IO::Exception(format!("{}", err)),
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -86,6 +86,8 @@ fn find_info(args: WithVM<RootStr>) -> IO<Result<String, String>> {
 
 struct Editor(Mutex<rustyline::Editor<()>>);
 
+impl Userdata for Editor { }
+
 impl fmt::Debug for Editor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Editor(..)")
@@ -100,9 +102,9 @@ impl Traverseable for Editor {
     fn traverse(&self, _: &mut Gc) {}
 }
 
-fn new_editor(_: ()) -> Userdata<Editor> {
+fn new_editor(_: ()) -> Editor {
     let editor = rustyline::Editor::new();
-    Userdata(Editor(Mutex::new(editor)))
+    Editor(Mutex::new(editor))
 }
 
 fn readline(editor: &Editor, prompt: &str) -> IO<Option<String>> {

--- a/test-nightly.sh
+++ b/test-nightly.sh
@@ -1,0 +1,7 @@
+(cd c-api &&
+    cargo test -p gluon_base --features test &&
+    cargo test -p gluon_parser --features test &&
+    cargo test -p gluon_check --features test &&
+    cargo test -p gluon_vm --features test &&
+    cargo test -p gluon --features "test nightly" &&
+    cargo test --features test)

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -2,7 +2,7 @@ extern crate env_logger;
 extern crate gluon;
 
 use gluon::base::types::Type;
-use gluon::vm::api::{self, VmType, FunctionRef};
+use gluon::vm::api::{VmType, FunctionRef, Userdata};
 use gluon::vm::thread::{RootedThread, Thread, Traverseable, Root, RootStr};
 use gluon::vm::types::VmInt;
 use gluon::Compiler;
@@ -52,6 +52,7 @@ fn root_data() {
 
     #[derive(Debug)]
     struct Test(VmInt);
+    impl Userdata for Test { }
     impl Traverseable for Test { }
     impl VmType for Test {
         type Type = Test;
@@ -72,8 +73,8 @@ fn root_data() {
       })
       .unwrap();
     load_script(&vm, "script_fn", expr).unwrap_or_else(|err| panic!("{}", err));
-    let mut script_fn: FunctionRef<fn(api::Userdata<Test>) -> VmInt> = vm.get_global("script_fn").unwrap();
-    let result = script_fn.call(api::Userdata(Test(123)))
+    let mut script_fn: FunctionRef<fn(Test) -> VmInt> = vm.get_global("script_fn").unwrap();
+    let result = script_fn.call(Test(123))
                           .unwrap();
     assert_eq!(result, 124);
 }

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -1,10 +1,12 @@
 extern crate gluon;
 use gluon::new_vm;
 use gluon::vm::gc::{Gc, Traverseable};
-use gluon::vm::api::{Pushable, VmType};
+use gluon::vm::api::{Pushable, VmType, Userdata};
 
 #[derive(Debug)]
 struct Test;
+
+impl Userdata for Test { }
 
 impl VmType for Test {
     type Type = Test;

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -3,10 +3,12 @@ use std::fmt;
 use std::sync::Mutex;
 
 use gluon::new_vm;
-use gluon::vm::api::VmType;
+use gluon::vm::api::{Userdata, VmType};
 use gluon::vm::gc::Traverseable;
 
 struct Test<'vm>(Mutex<&'vm str>);
+
+impl<'vm> Userdata for Test<'vm> { }
 
 impl<'vm> fmt::Debug for Test<'vm> {
     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -8,7 +8,7 @@ use gluon::vm::gc::Traverseable;
 
 struct Test<'vm>(Mutex<&'vm str>);
 
-impl<'vm> Userdata for Test<'vm> { }
+impl Userdata for Test<'static> { }
 
 impl<'vm> fmt::Debug for Test<'vm> {
     fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
@@ -28,5 +28,5 @@ fn f<'vm>(test: &'vm Test<'vm>, s: &'vm str) {
 fn main() {
     let vm = new_vm();
     let _ = vm.define_global("f", f as fn (_, _));
-    //~^ Error `vm` does not live long enough
+    //~^ `vm` does not live long enough
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -9,7 +9,10 @@ fn run_mode(mode: &'static str) {
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
-    config.target_rustcflags = Some("-L target/debug -L target/debug/deps".to_string());
+    // Pass flags for both c-api and without so both `cargo test ...` and
+    // `(cd c-api && cargo test ... )` works
+    config.target_rustcflags = Some("-L c-api/target/debug -L c-api/target/debug/deps \
+                                     -L target/debug -L target/debug/deps".to_string());
 
     compiletest::run_tests(&config);
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,18 +1,32 @@
 #![cfg(feature = "nightly")]
 extern crate compiletest_rs as compiletest;
 
+use std::env;
 use std::path::PathBuf;
 
 fn run_mode(mode: &'static str) {
+    // Retrieve the path where library dependencies are output
+    let mut out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    loop {
+        match out_dir.file_name() {
+            Some(name) => {
+                match name.to_str() {
+                    Some(name) if name == "deps" || name == "debug" => break,
+                    _ => (),
+                }
+            }
+            None => break,
+        }
+        out_dir.pop();
+    }
+
     let mut config = compiletest::default_config();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
 
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
-    // Pass flags for both c-api and without so both `cargo test ...` and
-    // `(cd c-api && cargo test ... )` works
-    config.target_rustcflags = Some("-L c-api/target/debug -L c-api/target/debug/deps \
-                                     -L target/debug -L target/debug/deps".to_string());
+    let dir = out_dir.to_str().unwrap();
+    config.target_rustcflags = Some(format!("-L {} -L {}/deps", dir, dir));
 
     compiletest::run_tests(&config);
 }

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -5,11 +5,10 @@ use std::marker::PhantomData;
 
 use base::types::{Type, TcType};
 use gc::{Gc, GcPtr, Traverseable};
-use stack::Stack;
-use vm::{Thread, Status};
+use vm::{Thread, Userdata};
 use thread::ThreadInternal;
 use value::Value;
-use api::{MaybeError, Generic, Pushable, Userdata, VmType, WithVM};
+use api::{MaybeError, Generic, VmType, WithVM};
 use api::generic::A;
 
 struct Reference<T> {
@@ -17,6 +16,8 @@ struct Reference<T> {
     thread: GcPtr<Thread>,
     _marker: PhantomData<T>,
 }
+
+impl<T> Userdata for Reference<T> where T: Any + Send + Sync { }
 
 impl<T> fmt::Debug for Reference<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -41,15 +42,6 @@ impl<T> VmType for Reference<T>
         let symbol = env.find_type_info("Ref").unwrap().name.clone();
         let ctor = Type::id(symbol);
         Type::app(ctor, vec![T::make_type(vm)])
-    }
-}
-
-impl<'vm, T> Pushable<'vm> for Reference<T>
-    where T: Any + Send + Sync + VmType,
-          T::Type: Sized
-{
-    fn push(self, vm: &'vm Thread, stack: &mut Stack) -> Status {
-        Userdata(self).push(vm, stack)
     }
 }
 

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::any::Any;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::result::Result as StdResult;
@@ -22,8 +21,6 @@ impl PartialEq for Userdata {
         self as *const _ == other as *const _
     }
 }
-
-impl<T> Userdata for T where T: Any + Traverseable + fmt::Debug + Send + Sync {}
 
 #[derive(Debug)]
 pub struct ClosureData {


### PR DESCRIPTION
By removing the blanket implementation on the `value::Userdata` trait. types can instead opt-in to use the `Userdata` representation in the vm. This means users only need to write `ìmpl Userdata for MyType { }` to allow them to define functions in gluon which create new values of `MyType` (`fn make_my_type(_: ()) -> MyType` works)