### PR TITLE
chore: Enable workspaces in cargo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Gluon can build with version 1.9.0 of Rust or later but we recommend to use vers
 
 To build and run all tests for Gluon you can use the `test.sh` script. If you look inside it you can see that it actually builds from the `c-api` directory (this is necessary as the `gluon_c-api` crate depends on the `gluon` crate). This means that all build artifacts end up in `c-api/target`. For this reason if you want to run tests only for a single crate you should run something like `(cd c-api && cargo test --features test -p gluon_check testname)`.
 
+If you are building with a nightly version of rust which supports workspaces you can use the `test-nightly.sh` script instead which puts the build artifacts in the root folder instead of in `c-api`.
+
 ## Pull requests
 
 Once you have made some changes you will need to file a pull request to get your changes merged into the main repository. If the code is still a work in progress it can still be a good idea to submit a PR as that will let other contributors see your progress and provide assistance (you may prefix the PR message with [WIP] to make it explicit that the PR is incomplete).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/Marwes/gluon"
 documentation = "https://marwes.github.io/gluon/gluon/index.html"
 readme = "README.md"
 
+[workspace]
+members = ["c-api"]
+
 [lib]
 
 name = "gluon"

--- a/test-nightly.sh
+++ b/test-nightly.sh
@@ -1,7 +1,6 @@
-(cd c-api &&
-    cargo test -p gluon_base --features test &&
+cargo test -p gluon_base --features test &&
     cargo test -p gluon_parser --features test &&
     cargo test -p gluon_check --features test &&
     cargo test -p gluon_vm --features test &&
-    cargo test -p gluon --features "test nightly" &&
-    cargo test --features test)
+    cargo test --features "test nightly" &&
+    (cd c-api && cargo test --features test)


### PR DESCRIPTION
This will let nightly users to build directly in the root folder.