### PR TITLE
feat(repl): Add completion to the repl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-cache: cargo
 sudo: false
 addons:
   apt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ env_logger = { version = "0.3.4", optional = true }
 lazy_static = { version = "0.2.0", optional = true }
 log = "0.3.6"
 quick-error = "1.0.0"
-rustyline = { git = "https://github.com/kkawakam/rustyline", rev = "480bf15", optional = true }
+rustyline = { git = "https://github.com/kkawakam/rustyline", rev = "d1ca6b92432f4ce6acbf20be6b90a328463a9f9d", optional = true }
 gluon_base = { path = "base", version = "0.1.3" }
 gluon_check = { path = "check", version = "0.1.3" }
 gluon_parser = { path = "parser", version = "0.1.2" }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ REPL features:
         type std.prelude.List a = | Nil | Cons a (std.prelude.List a)
         /// A linked list type
 
+* Tab-completion of identifiers and record fields
+    ![repl completion](http://i.imgur.com/IXLQFtV.gif)
 * Exit the REPL by writing `:q`
 
 ## Documentation


### PR DESCRIPTION
This has the usual caveat that completing other modules will not work and they must be explicitly imported first

```
let prelude = import "std/prelude.glu"
prelude.n // Yields prelude.not, prelude.num_Int, etc
```
```
prelude. // Nothing
std.prelude. // Nothing
```