### PR TITLE
fix(completion): Give completion for local variables when pointing to whitespace

### DIFF
--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -174,7 +174,7 @@ impl<F> FindVisitor<F>
         
         match current.value {
             Identifier(_) | Literal(_) => {
-                if current.span(self.env).containment(&self.location) == Ordering::Equal {
+                if current.span.containment(&self.location) == Ordering::Equal {
                     self.on_found.expr(current)
                 } else {
                     self.on_found.nothing()
@@ -257,7 +257,7 @@ pub fn find<T>(env: &T, expr: &SpannedExpr<TcIdent<Symbol>>, location: Location)
 pub fn suggest<T>(env: &T,
                   expr: &SpannedExpr<TcIdent<Symbol>>,
                   location: Location)
-                  -> Vec<TcIdent<Symbol>>
+                  -> Vec<Suggestion>
     where T: TypeEnv
 {
     let mut visitor = FindVisitor {

--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -43,10 +43,15 @@ impl<E: TypeEnv> OnFound for GetType<E> {
     fn nothing(&mut self) {}
 }
 
+pub struct Suggestion {
+    pub name: String,
+    pub typ: TcType,
+}
+
 struct Suggest<E> {
     env: E,
     stack: ScopedMap<Symbol, TcType>,
-    result: Vec<TcIdent<Symbol>>,
+    result: Vec<Suggestion>,
 }
 
 impl<E: TypeEnv> OnFound for Suggest<E> {
@@ -80,8 +85,8 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
         if let Expr::Identifier(ref ident) = expr.value {
             for (k, typ) in self.stack.iter() {
                 if k.declared_name().starts_with(ident.name.declared_name()) {
-                    self.result.push(TcIdent {
-                        name: k.clone(),
+                    self.result.push(Suggestion {
+                        name: k.declared_name().into(),
                         typ: typ.clone(),
                     });
                 }
@@ -96,8 +101,8 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
                 let id = ident.name.as_ref();
                 for field in fields {
                     if field.name.as_ref().starts_with(id) {
-                        self.result.push(TcIdent {
-                            name: field.name.clone(),
+                        self.result.push(Suggestion {
+                            name: field.name.declared_name().into(),
                             typ: field.typ.clone(),
                         });
                     }
@@ -108,8 +113,8 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
 
     fn nothing(&mut self) {
         self.result.extend(self.stack.iter().map(|(name, typ)| {
-            TcIdent {
-                name: name.clone(),
+            Suggestion {
+                name: name.declared_name().into(),
                 typ: typ.clone(),
             }
         }));

--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -47,7 +47,7 @@ fn identifier() {
                                   Location {
                                       line: 1,
                                       column: CharPos(16),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(45),
                                   });
     let expected = Ok(typ("Int"));
     assert_eq!(result, expected);
@@ -57,7 +57,7 @@ fn identifier() {
                                   Location {
                                       line: 1,
                                       column: CharPos(17),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(16),
                                   });
     let expected = Ok(typ("Int"));
     assert_eq!(result, expected);
@@ -67,7 +67,7 @@ fn identifier() {
                                   Location {
                                       line: 1,
                                       column: CharPos(18),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(17),
                                   });
     let expected = Ok(typ("Int"));
     assert_eq!(result, expected);
@@ -77,7 +77,7 @@ fn identifier() {
                                   Location {
                                       line: 1,
                                       column: CharPos(19),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(18),
                                   });
     assert_eq!(result, Err(()));
 }
@@ -88,7 +88,7 @@ fn literal_string() {
                            Location {
                                line: 1,
                                column: CharPos(2),
-                               absolute: BytePos(0),
+                               absolute: BytePos(1),
                            });
     let expected = Ok(typ("String"));
 
@@ -105,7 +105,7 @@ and g x = "asd"
                            Location {
                                line: 3,
                                column: CharPos(15),
-                               absolute: BytePos(0),
+                               absolute: BytePos(25),
                            });
     let expected = Ok(typ("String"));
 
@@ -146,7 +146,7 @@ let (++) l r =
                                   Location {
                                       line: 6,
                                       column: CharPos(4),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(63),
                                   });
     let expected = Ok(Type::function(vec![typ("Int"), typ("Float")], typ("Int")));
     assert_eq!(result, expected);
@@ -156,7 +156,7 @@ let (++) l r =
                                   Location {
                                       line: 6,
                                       column: CharPos(1),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(54),
                                   });
     let expected = Ok(typ("Int"));
     assert_eq!(result, expected);
@@ -166,7 +166,7 @@ let (++) l r =
                                   Location {
                                       line: 6,
                                       column: CharPos(6),
-                                      absolute: BytePos(123),
+                                      absolute: BytePos(59),
                                   });
     let expected = Ok(typ("Float"));
     assert_eq!(result, expected);
@@ -174,7 +174,6 @@ let (++) l r =
 
 #[test]
 fn field_access() {
-    let env = ast::EmptyEnv::new();
     let typ_env = MockEnv::new();
 
     let (mut expr, result) = support::typecheck_expr(r#"
@@ -183,13 +182,12 @@ r.x
 "#);
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
-    let result = completion::find(&env,
-                                  &typ_env,
+    let result = completion::find(&typ_env,
                                   &mut expr,
                                   Location {
                                       line: 3,
                                       column: CharPos(1),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(21),
                                   });
     let expected = Ok(Type::record(vec![],
                                    vec![Field {
@@ -198,13 +196,12 @@ r.x
                                         }]));
     assert_eq!(result, expected);
 
-    let result = completion::find(&env,
-                                  &typ_env,
+    let result = completion::find(&typ_env,
                                   &mut expr,
                                   Location {
                                       line: 3,
                                       column: CharPos(3),
-                                      absolute: BytePos(0),
+                                      absolute: BytePos(23),
                                   });
     let expected = Ok(typ("Int"));
     assert_eq!(result, expected);
@@ -221,7 +218,7 @@ fn in_record() {
                            Location {
                                line: 3,
                                column: CharPos(14),
-                               absolute: BytePos(0),
+                               absolute: BytePos(30),
                            });
     let expected = Ok(typ("Int"));
 
@@ -239,7 +236,7 @@ te
                          Location {
                              line: 5,
                              column: CharPos(1),
-                             absolute: BytePos(0),
+                             absolute: BytePos(47),
                          });
     let expected = Ok(vec!["tes".into(), "test".into()]);
 
@@ -256,7 +253,7 @@ let f test =
                          Location {
                              line: 3,
                              column: CharPos(17),
-                             absolute: BytePos(0),
+                             absolute: BytePos(61),
                          });
     let expected = Ok(vec!["test".into(), "test2".into()]);
 
@@ -273,7 +270,7 @@ record.a
                          Location {
                              line: 4,
                              column: CharPos(8),
-                             absolute: BytePos(0),
+                             absolute: BytePos(104),
                          });
     let expected = Ok(vec!["aa".into(), "ab".into()]);
 
@@ -291,7 +288,7 @@ record.ab
                          Location {
                              line: 5,
                              column: CharPos(8),
-                             absolute: BytePos(0),
+                             absolute: BytePos(108),
                          });
     let expected = Ok(vec!["abc".into()]);
 
@@ -323,7 +320,7 @@ a
                          Location {
                              line: 3,
                              column: CharPos(1),
-                             absolute: BytePos(0),
+                             absolute: BytePos(45),
                          });
     let expected = Ok(vec!["aa".into()]);
 
@@ -339,7 +336,7 @@ record.aa
                          Location {
                              line: 3,
                              column: CharPos(4),
-                             absolute: BytePos(0),
+                             absolute: BytePos(47),
                          });
     let expected = Ok(vec!["record".into()]);
 
@@ -356,7 +353,7 @@ abc
                          Location {
                              line: 4,
                              column: CharPos(3),
-                             absolute: BytePos(0),
+                             absolute: BytePos(45),
                          });
     let expected = Ok(vec!["abc".into()]);
 
@@ -373,7 +370,7 @@ abc
                          Location {
                              line: 4,
                              column: CharPos(5),
-                             absolute: BytePos(0),
+                             absolute: BytePos(32),
                          });
     let expected = Ok(vec!["abb".into(), "abc".into()]);
 

--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -376,3 +376,32 @@ abc
 
     assert_eq!(result, expected);
 }
+
+#[test]
+fn suggest_between_expressions() {
+    let text = r#"
+let abc = 1
+let abb = 2
+test  test1
+""  123
+"#;
+    let result = suggest(text,
+                         Location {
+                             line: 4,
+                             column: CharPos(6),
+                             absolute: BytePos(33),
+                         });
+    let expected = Ok(vec!["abb".into(), "abc".into()]);
+
+    assert_eq!(result, expected);
+
+    let result = suggest(text,
+                         Location {
+                             line: 5,
+                             column: CharPos(4),
+                             absolute: BytePos(44),
+                         });
+    let expected = Ok(vec!["abb".into(), "abc".into()]);
+
+    assert_eq!(result, expected);
+}

--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -27,7 +27,7 @@ fn suggest(s: &str, location: Location) -> Result<Vec<String>, ()> {
     let mut vec: Vec<String> = {
         completion::suggest(&env, &mut expr, location)
             .into_iter()
-            .map(|ident| ident.name.declared_name().to_string())
+            .map(|ident| ident.name)
             .collect()
     };
     vec.sort();

--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -79,8 +79,7 @@ fn identifier() {
                                       column: CharPos(19),
                                       absolute: BytePos(0),
                                   });
-    let expected = Ok(typ("Int"));
-    assert_eq!(result, expected);
+    assert_eq!(result, Err(()));
 }
 
 #[test]
@@ -285,7 +284,7 @@ a
 "#,
                          Location {
                              line: 3,
-                             column: CharPos(7),
+                             column: CharPos(1),
                              absolute: BytePos(0),
                          });
     let expected = Ok(vec!["aa".into()]);
@@ -305,6 +304,40 @@ record.aa
                              absolute: BytePos(0),
                          });
     let expected = Ok(vec!["record".into()]);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn suggest_end_of_identifier() {
+    let result = suggest(r#"
+let abc = 1
+let abb = 2
+abc 
+"#,
+                         Location {
+                             line: 4,
+                             column: CharPos(3),
+                             absolute: BytePos(0),
+                         });
+    let expected = Ok(vec!["abc".into()]);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn suggest_after_identifier() {
+    let result = suggest(r#"
+let abc = 1
+let abb = 2
+abc 
+"#,
+                         Location {
+                             line: 4,
+                             column: CharPos(5),
+                             absolute: BytePos(0),
+                         });
+    let expected = Ok(vec!["abb".into(), "abc".into()]);
 
     assert_eq!(result, expected);
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -94,7 +94,7 @@ impl Importer for CheckImporter {
 /// already loaded and then a global access to the loaded module
 pub struct Import<I = DefaultImporter> {
     visited: RwLock<Vec<String>>,
-    paths: RwLock<Vec<PathBuf>>,
+    pub paths: RwLock<Vec<PathBuf>>,
     pub importer: I,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,8 +587,8 @@ pub fn filename_to_module(filename: &str) -> StdString {
                 .map(|ext| &filename[..filename.len() - ext.len() - 1])
                 .unwrap_or(filename)
         });
-
-    name.replace("/", ".")
+    
+    name.replace(|c: char| c == '/' || c == '\\', ".")
 }
 
 /// Creates a new virtual machine with support for importing other modules and with all primitives


### PR DESCRIPTION
Before the closest identifier to the left of the location would be completed which meant
```f#
test   abc
//   ^ completion here would complete `test` instead of listing local variables
```
This fix ensures that local variables are enumerated instead.