### PR TITLE
chore: Enable building with stable rustc again on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 rust:
 - nightly
 - beta
+- stable
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&


### PR DESCRIPTION
With 1.11 released building on stable should no longer trigger timeouts.