### PR TITLE
Disable beta on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 rust:
 - nightly
 # - beta
+- stable
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libdw-dev
 rust:
 - nightly
-- beta
+# - beta
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&


### PR DESCRIPTION
The regression in rust-lang/rust#35721 will most likely not be backported to beta until next week - see https://github.com/rust-lang/rust/pull/35733#issuecomment-241099928 - so it probably makes sense to disable it for now.

I also cherrypicked #120 because it would have caused a conflict.