### PR TITLE
perf: Use a single mutex for both the stack and gc

### DIFF
--- a/benches/function_call.rs
+++ b/benches/function_call.rs
@@ -5,7 +5,8 @@ extern crate test;
 extern crate gluon;
 
 use gluon::{Compiler, new_vm};
-use gluon::vm::api::FunctionRef;
+use gluon::vm::thread::{Status, Thread};
+use gluon::vm::api::{FunctionRef, primitive};
 
 // Benchmarks function calls
 #[bench]
@@ -51,22 +52,35 @@ fn factorial_tail_call(b: &mut ::test::Bencher) {
 #[bench]
 fn gluon_rust_boundary_overhead(b: &mut ::test::Bencher) {
     let vm = new_vm();
+
+    fn test_fn(_: &Thread) -> Status { Status::Ok }
+    vm.define_global("test_fn", primitive::<fn (i32)>("test_fn", test_fn)).unwrap();
+
     let text = r#"
-    let { trim } = import "std/string.glu"
     let for n f =
         if n #Int== 0 then
             ()
         else
             f n
+            f n
+            f n
+            f n
+            f n
+            f n
+            f n
+            f n
+            f n
+            f n
             for (n #Int- 10) f
-    \n -> for n \_ -> trim ""
+    \n -> for n test_fn
     "#;
     Compiler::new()
         .load_script(&vm, "test", text)
         .unwrap();
-    let mut factorial: FunctionRef<fn (i32) -> ()> = vm.get_global("test").unwrap();
+
+    let mut test: FunctionRef<fn (i32) -> ()> = vm.get_global("test").unwrap();
     b.iter(|| {
-        let result = factorial.call(1000).unwrap();
+        let result = test.call(1000).unwrap();
         ::test::black_box(result)
     })
 }

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn glu_load_script(vm: &Thread,
 }
 
 pub extern "C" fn glu_call_function(thread: &Thread, arguments: VmIndex) -> Error {
-    let stack = thread.current_frame();
+    let stack = thread.get_stack();
     match thread.call_function(stack, arguments) {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,
@@ -84,11 +84,13 @@ pub extern "C" fn glu_call_function(thread: &Thread, arguments: VmIndex) -> Erro
 }
 
 pub extern "C" fn glu_len(vm: &Thread) -> usize {
-    vm.current_frame().len() as usize
+    let mut stack = vm.get_stack();
+    let stack = stack.current_frame();
+    stack.len() as usize
 }
 
 pub extern "C" fn glu_pop(vm: &Thread, n: usize) {
-    let mut stack = vm.current_frame();
+    let mut stack = vm.get_stack();
     for _ in 0..n {
         stack.pop();
     }
@@ -180,7 +182,8 @@ pub unsafe extern "C" fn glu_get_string(vm: &Thread,
                                         out: &mut *const u8,
                                         out_len: &mut usize)
                                         -> Error {
-    let stack = vm.current_frame();
+    let mut stack = vm.get_stack();
+    let stack = stack.current_frame();
     match stack.get_variants(index).and_then(|value| <&str>::from_value(vm, value)) {
         Some(value) => {
             *out = &*value.as_ptr();
@@ -206,7 +209,8 @@ pub extern "C" fn glu_get_light_userdata(vm: &Thread,
 fn get_value<T>(vm: &Thread, index: VmIndex, out: &mut T) -> Error
     where T: for<'vm> Getable<'vm>
 {
-    let stack = vm.current_frame();
+    let mut stack = vm.get_stack();
+    let stack = stack.current_frame();
     match stack.get_variants(index).and_then(|value| T::from_value(vm, value)) {
         Some(value) => {
             *out = value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,8 +309,8 @@ pub mod compiler_pipeline {
             function.id = Symbol::new(name);
             let function = try!(vm.global_env().new_function(function));
             let closure = {
-                let stack = vm.current_frame();
-                try!(vm.alloc(&stack.stack, ClosureDataDef(function, &[])))
+                let stack = vm.get_stack();
+                try!(vm.alloc(&stack, ClosureDataDef(function, &[])))
             };
             let value = try!(vm.call_module(&typ, closure));
             Ok((vm.root_value_ref(value), typ))
@@ -327,8 +327,8 @@ pub mod compiler_pipeline {
             let metadata = metadata::metadata(&*vm.get_env(), &mut expr);
             let function = try!(vm.global_env().new_function(function));
             let closure = {
-                let stack = vm.current_frame();
-                try!(vm.alloc(&stack.stack, ClosureDataDef(function, &[])))
+                let stack = vm.get_stack();
+                try!(vm.alloc(&stack, ClosureDataDef(function, &[])))
             };
             let value = try!(vm.call_module(&typ, closure));
             try!(vm.global_env().set_global(function.name.clone(), typ, metadata, value));
@@ -461,8 +461,8 @@ impl Compiler {
         let function = try!(self.compile_script(vm, filename, &expr));
         let function = try!(vm.global_env().new_function(function));
         let closure = {
-            let stack = vm.current_frame();
-            try!(vm.alloc(&stack.stack, ClosureDataDef(function, &[])))
+            let stack = vm.get_stack();
+            try!(vm.alloc(&stack, ClosureDataDef(function, &[])))
         };
         let value = try!(vm.call_module(&typ, closure));
         try!(vm.global_env().set_global(function.name.clone(), typ, metadata, value));
@@ -494,8 +494,8 @@ impl Compiler {
         function.id = Symbol::new(name);
         let function = try!(vm.global_env().new_function(function));
         let closure = {
-            let stack = vm.current_frame();
-            try!(vm.alloc(&stack.stack, ClosureDataDef(function, &[])))
+            let stack = vm.get_stack();
+            try!(vm.alloc(&stack, ClosureDataDef(function, &[])))
         };
         let value = try!(vm.call_module(&typ, closure));
         Ok((vm.root_value_ref(value), typ))

--- a/test-nightly.sh
+++ b/test-nightly.sh
@@ -3,4 +3,4 @@ cargo test -p gluon_base --features test &&
     cargo test -p gluon_check --features test &&
     cargo test -p gluon_vm --features test &&
     cargo test --features "test nightly" &&
-    (cd c-api && cargo test --features test)
+    (cd c-api && cargo test --features "test nightly")

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -6,7 +6,7 @@ use gluon::vm::api::{FunctionRef, Generic, Getable, VmType, OpaqueValue};
 use gluon::vm::thread::{RootedThread, Thread, ThreadInternal};
 use gluon::vm::internal::Value;
 use gluon::vm::internal::Value::{Float, Int};
-use gluon::vm::stack::State;
+use gluon::vm::stack::{State, StackFrame};
 use gluon::vm::channel::Sender;
 use gluon::vm::Error as VMError;
 use gluon::import::Import;
@@ -222,7 +222,8 @@ in f 4
 fn insert_stack_slice() {
     let _ = ::env_logger::init();
     let vm = make_vm();
-    let mut stack = vm.current_frame();
+    let mut stack = vm.get_stack();
+    let mut stack = StackFrame::current(&mut stack);
     stack.push(Int(0));
     stack.insert_slice(0, &[Int(2), Int(1)]);
     assert_eq!(&stack[..], [Int(2), Int(1), Int(0)]);

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -141,7 +141,7 @@ fn record() {
 ";
     let mut vm = make_vm();
     let value = run_expr::<Generic<A>>(&mut vm, text);
-    assert_eq!(value.0, vm.new_data(0, &mut [Int(0), Float(1.0), Value::Tag(0)]).unwrap());
+    assert_eq!(value.0, vm.context().new_data(&vm, 0, &mut [Int(0), Float(1.0), Value::Tag(0)]).unwrap());
 }
 
 #[test]
@@ -154,7 +154,7 @@ add { x = 0, y = 1 } { x = 1, y = 1 }
 ";
     let mut vm = make_vm();
     let value = run_expr::<Generic<A>>(&mut vm, text);
-    assert_eq!(value.0, vm.new_data(0, &mut [Int(1), Int(2)]).unwrap());
+    assert_eq!(value.0, vm.context().new_data(&vm, 0, &mut [Int(1), Int(2)]).unwrap());
 }
 #[test]
 fn script() {
@@ -173,7 +173,7 @@ let { T, add, sub } = Vec
 in add { x = 10, y = 5 } { x = 1, y = 2 }
 "#;
     let value = run_expr::<Generic<A>>(&mut vm, script);
-    assert_eq!(value.0, vm.new_data(0, &mut [Int(11), Int(7)]).unwrap());
+    assert_eq!(value.0, vm.context().new_data(&vm, 0, &mut [Int(11), Int(7)]).unwrap());
 }
 #[test]
 fn adt() {
@@ -184,7 +184,7 @@ in Some 1
 ";
     let mut vm = make_vm();
     let value = run_expr::<Generic<A>>(&mut vm, text);
-    assert_eq!(value.0, vm.new_data(1, &mut [Int(1)]).unwrap());
+    assert_eq!(value.0, vm.context().new_data(&vm, 1, &mut [Int(1)]).unwrap());
 }
 
 
@@ -222,12 +222,12 @@ in f 4
 fn insert_stack_slice() {
     let _ = ::env_logger::init();
     let vm = make_vm();
-    let mut stack = vm.get_stack();
-    let mut stack = StackFrame::current(&mut stack);
+    let mut context = vm.context();
+    let mut stack = StackFrame::current(&mut context.stack);
     stack.push(Int(0));
     stack.insert_slice(0, &[Int(2), Int(1)]);
     assert_eq!(&stack[..], [Int(2), Int(1), Int(0)]);
-    stack = stack.enter_scope(2, State::Unknown);
+    stack.enter_scope(2, State::Unknown);
     stack.insert_slice(1, &[Int(10)]);
     assert_eq!(&stack[..], [Int(1), Int(10), Int(0)]);
     stack.insert_slice(1, &[]);
@@ -611,7 +611,7 @@ in
 "#;
     let mut vm = make_vm();
     let result = run_expr::<Generic<A>>(&mut vm, text);
-    assert_eq!(result.0, vm.new_data(0, &mut [Int(3), Float(3.0)]).unwrap());
+    assert_eq!(result.0, vm.context().new_data(&vm, 0, &mut [Int(3), Float(3.0)]).unwrap());
 }
 
 test_expr!{ through_overloaded_alias,

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -1444,25 +1444,28 @@ where $($args: Getable<'vm> + 'vm,)*
     #[allow(non_snake_case, unused_mut, unused_assignments, unused_variables, unused_unsafe)]
     fn unpack_and_call(&self, vm: &'vm Thread) -> Status {
         let n_args = Self::arguments();
-        let mut stack = vm.current_frame();
+        let mut stack = vm.get_stack();
         let mut i = 0;
         let r = unsafe {
-            $(let $args = {
-                let x = $args::from_value_unsafe(vm, Variants(&stack[i]))
-                    .expect(stringify!(Argument $args));
-                i += 1;
-                x
-            });*;
-            // Lock the frame to ensure that any reference from_value_unsafe may have returned stay
-            // rooted
-            let lock = stack.into_lock();
+            let (lock, ($($args,)*)) = {
+                let stack = StackFrame::current(&mut stack);
+                $(let $args = {
+                    let x = $args::from_value_unsafe(vm, Variants(&stack[i]))
+                        .expect(stringify!(Argument $args));
+                    i += 1;
+                    x
+                });*;
+                // Lock the frame to ensure that any reference from_value_unsafe may have returned stay
+                // rooted
+                (stack.into_lock(), ($($args,)*))
+            };
+            drop(stack);
             let r = (*self)($($args),*);
-            let mut s = vm.get_stack();
-            s.release_lock(lock);
-            stack = StackFrame::current(s);
+            stack = vm.get_stack();
+            stack.release_lock(lock);
             r
         };
-        r.status_push(vm, &mut stack.stack)
+        r.status_push(vm, &mut stack)
     }
 }
 
@@ -1489,25 +1492,28 @@ where $($args: Getable<'vm> + 'vm,)*
     #[allow(non_snake_case, unused_mut, unused_assignments, unused_variables, unused_unsafe)]
     fn unpack_and_call(&self, vm: &'vm Thread) -> Status {
         let n_args = Self::arguments();
-        let mut stack = vm.current_frame();
+        let mut stack = vm.get_stack();
         let mut i = 0;
         let r = unsafe {
-            $(let $args = {
-                let x = $args::from_value_unsafe(vm, Variants(&stack[i]))
-                    .expect(stringify!(Argument $args));
-                i += 1;
-                x
-            });*;
-            // Lock the frame to ensure that any reference from_value_unsafe may have returned stay
-            // rooted
-            let lock = stack.into_lock();
+            let (lock, ($($args,)*)) = {
+                let stack = StackFrame::current(&mut stack);
+                $(let $args = {
+                    let x = $args::from_value_unsafe(vm, Variants(&stack[i]))
+                        .expect(stringify!(Argument $args));
+                    i += 1;
+                    x
+                });*;
+                // Lock the frame to ensure that any reference from_value_unsafe may have returned stay
+                // rooted
+                (stack.into_lock(), ($($args,)*))
+            };
+            drop(stack);
             let r = (*self)($($args),*);
-            let mut s = vm.get_stack();
-            s.release_lock(lock);
-            stack = StackFrame::current(s);
+            stack = vm.get_stack();
+            stack.release_lock(lock);
             r
         };
-        r.status_push(vm, &mut stack.stack)
+        r.status_push(vm, &mut stack)
     }
 }
 
@@ -1520,8 +1526,7 @@ impl<'vm, T, $($args,)* R> Function<T, fn($($args),*) -> R>
     pub fn call(&'vm mut self $(, $args: $args)*) -> Result<R> {
         let vm = self.value.vm();
         let mut stack = vm.get_stack();
-        StackFrame::current(stack).enter_scope(0, State::Unknown);
-        stack = vm.get_stack();
+        StackFrame::current(&mut stack).enter_scope(0, State::Unknown);
         stack.push(*self.value);
         $(
             try!($args.push(vm, &mut stack));
@@ -1529,8 +1534,8 @@ impl<'vm, T, $($args,)* R> Function<T, fn($($args),*) -> R>
         for _ in 0..R::extra_args() {
             0.push(vm, &mut stack).unwrap();
         }
-        let args = stack.len() - 1;
-        let mut stack = try!(vm.call_function(StackFrame::current(stack), args)).unwrap();
+        let args = count!($($args),*) + R::extra_args();
+        let mut stack = try!(vm.call_function(stack, args)).unwrap();
         let result = stack.pop();
         R::from_value(vm, Variants(&result))
             .ok_or_else(|| {

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -123,29 +123,29 @@ fn send(sender: &Sender<Generic<A>>, value: Generic<A>) -> Result<(), ()> {
 }
 
 fn resume(vm: &Thread) -> Status {
-    let mut stack = vm.get_stack();
-    let value = StackFrame::current(&mut stack)[0];
+    let mut context = vm.context();
+    let value = StackFrame::current(&mut context.stack)[0];
     match value {
         Value::Thread(child) => {
-            let lock = StackFrame::current(&mut stack).into_lock();
-            drop(stack);
+            let lock = StackFrame::current(&mut context.stack).into_lock();
+            drop(context);
             let result = child.resume();
-            stack = vm.get_stack();
-            stack.release_lock(lock);
+            context = vm.context();
+            context.stack.release_lock(lock);
             match result {
                 Ok(()) |
                 Err(Error::Yield) => {
                     let value: Result<(), &str> = Ok(());
-                    value.status_push(vm, &mut stack)
+                    value.status_push(vm, &mut context)
                 }
                 Err(Error::Dead) => {
                     let value: Result<(), &str> = Err("Attempted to resume a dead thread");
-                    value.status_push(vm, &mut stack)
+                    value.status_push(vm, &mut context)
                 }
                 Err(err) => {
                     let fmt = format!("{}", err);
-                    let result = Value::String(vm.alloc_ignore_limit(&fmt[..]));
-                    stack.push(result);
+                    let result = Value::String(context.alloc_ignore_limit(&fmt[..]));
+                    context.stack.push(result);
                     Status::Error
                 }
             }
@@ -167,15 +167,15 @@ fn spawn<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> MaybeError<R
 fn spawn_<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> VmResult<RootedThread> {
     let thread = try!(value.vm.new_thread());
     {
-        let mut stack = thread.get_stack();
+        let mut context = thread.context();
         let callable = match value.value.value() {
             Value::Closure(c) => State::Closure(c),
             Value::Function(c) => State::Extern(c),
             _ => State::Unknown,
         };
-        try!(value.value.push(value.vm, &mut stack));
-        stack.push(Value::Int(0));
-        StackFrame::current(&mut stack).enter_scope(1, callable);
+        try!(value.value.push(value.vm, &mut context));
+        context.stack.push(Value::Int(0));
+        StackFrame::current(&mut context.stack).enter_scope(1, callable);
     }
     Ok(thread)
 }

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -65,12 +65,11 @@ fn array_append<'vm>(lhs: Array<'vm, Generic<generic::A>>,
     }
     let vm = lhs.vm();
     let value = {
-        let stack = vm.get_stack();
-        let result = vm.alloc(&stack,
-                              Append {
-                                  lhs: &lhs,
-                                  rhs: &rhs,
-                              });
+        let mut context = vm.context();
+        let result = context.alloc(Append {
+            lhs: &lhs,
+            rhs: &rhs,
+        });
         match result {
             Ok(x) => x,
             Err(err) => return MaybeError::Err(err),
@@ -111,12 +110,11 @@ fn string_append(lhs: WithVM<&str>, rhs: &str) -> MaybeError<String, Error> {
     let vm = lhs.vm;
     let lhs = lhs.value;
     let value = {
-        let stack = vm.get_stack();
-        let result = vm.alloc(&stack,
-                              StrAppend {
-                                  lhs: lhs,
-                                  rhs: rhs,
-                              });
+        let mut context = vm.context();
+        let result = context.alloc(StrAppend {
+            lhs: lhs,
+            rhs: rhs,
+        });
         match result {
             Ok(x) => x,
             Err(err) => return MaybeError::Err(err),


### PR DESCRIPTION
This gives a noticeable performance improvement for code which frequently enters and leaves the vm itself as only one mutex need to be locked. It does complicate some of the surrounding code slightly but this will be a necessary change regardless since the now added `Contex` type can be extended with additional fields which would otherwise involve adding more locks.

Before
```
test factorial                    ... bench:     249,725 ns/iter (+/- 12,150)
test factorial_tail_call          ... bench:     242,908 ns/iter (+/- 13,685)
test gluon_rust_boundary_overhead ... bench:     396,684 ns/iter (+/- 34,313)
```

After
```
test factorial                    ... bench:     128,571 ns/iter (+/- 7,537)
test factorial_tail_call          ... bench:     125,914 ns/iter (+/- 6,374)
test gluon_rust_boundary_overhead ... bench:     237,173 ns/iter (+/- 11,306)
```