### PR TITLE
chore: Only test using skeptic on stable when running in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libdw-dev
 rust:
 - nightly
-# - beta
+- beta
 - stable
 before_script:
 - |
@@ -16,8 +16,9 @@ before_script:
   export PATH=$HOME/.local/bin:$PATH
 script:
 - |
-  sh ./test.sh &&
+  sh ./test-no-skeptic.sh &&
   travis-cargo --only nightly test -- --features "test nightly" -p gluon compile_test &&
+  travis-cargo --only stable test -- --features "test skeptic" -p gluon --test skeptic-tests &&
   cargo build --release &&
   travis-cargo --only nightly bench &&
   travis-cargo --only stable doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,23 +27,25 @@ name = "repl"
 path = "src/main.rs"
 
 [dependencies]
-clap = "2.2.5"
-compiletest_rs = { version = "0.2", optional = true }
-env_logger = { version = "0.3.4", optional = true }
-lazy_static = { version = "0.2.0", optional = true }
-log = "0.3.6"
-quick-error = "1.0.0"
-rustyline = { version = "1.0.0", optional = true }
 gluon_base = { path = "base", version = "0.1.3" }
 gluon_check = { path = "check", version = "0.1.3" }
 gluon_parser = { path = "parser", version = "0.1.2" }
 gluon_vm = { path = "vm", version = "0.1.2" }
 
-[build-dependencies]
-skeptic = "0.6"
+clap = "2.2.5"
+log = "0.3.6"
+quick-error = "1.0.0"
 
-[dev-dependencies]
-skeptic = "0.6"
+env_logger = { version = "0.3.4", optional = true }
+lazy_static = { version = "0.2.0", optional = true }
+rustyline = { version = "1.0.0", optional = true }
+
+# Crates used in testing Testing
+compiletest_rs = { version = "0.2", optional = true }
+skeptic = { version = "0.6", optional = true }
+
+[build-dependencies]
+skeptic = { version = "0.6", optional = true }
 
 [features]
 default = ["repl"]

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -13,3 +13,4 @@ gluon = { version = "0.1.3", path = ".." }
 [features]
 test = ["gluon/test"]
 nightly = ["gluon/nightly"]
+skeptic = ["gluon/skeptic"]

--- a/test-nightly.sh
+++ b/test-nightly.sh
@@ -2,5 +2,5 @@ cargo test -p gluon_base --features test &&
     cargo test -p gluon_parser --features test &&
     cargo test -p gluon_check --features test &&
     cargo test -p gluon_vm --features test &&
-    cargo test --features "test nightly" &&
-    (cd c-api && cargo test --features "test nightly")
+    cargo test --features "test skeptic nightly" &&
+    (cd c-api && cargo test --features "test skeptic nightly")

--- a/test-no-skeptic.sh
+++ b/test-no-skeptic.sh
@@ -3,5 +3,5 @@
     cargo test -p gluon_parser --features test &&
     cargo test -p gluon_check --features test &&
     cargo test -p gluon_vm --features test &&
-    cargo test -p gluon --features "test skeptic" &&
-    cargo test --features "test skeptic")
+    cargo test -p gluon --features test &&
+    cargo test --features test)

--- a/tests/skeptic-tests.rs
+++ b/tests/skeptic-tests.rs
@@ -1,1 +1,2 @@
+#![cfg(feature = "skeptic")]
 include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This solution feels a bit heavy handed but at least it seems like skeptic no longer fails on travis from the 5 or so times I reran it.

This also enables beta testing again on travis since the rustc fixes has been backported.

Fixes #149