### PR TITLE
fix: Don't return None from Source::location when byte is at end of file

### DIFF
--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -54,9 +54,9 @@ struct SourceContext<E> {
 
 impl<E> SourceContext<E> {
     fn new(source: &Source, error: Spanned<E, BytePos>) -> SourceContext<E> {
-        let start = source.location(error.span.start).unwrap();
-        let end = source.location(error.span.end).unwrap();
-        let (_, line) = source.line_at_byte(error.span.start).unwrap();
+        let start = source.location(error.span.start).expect("SourceContext: start location");
+        let end = source.location(error.span.end).expect("SourceContext: end location");
+        let (_, line) = source.line_at_byte(error.span.start).expect("SourceContext: line");
 
         SourceContext {
             line: line.to_string(),

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -105,6 +105,7 @@ impl PrimitiveEnv for MockEnv {
 #[allow(dead_code)]
 pub struct MockIdentEnv<T>(PhantomData<T>);
 
+#[allow(dead_code)]
 impl<T> MockIdentEnv<T> {
     pub fn new() -> MockIdentEnv<T> {
         MockIdentEnv(PhantomData)

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,15 @@
+extern crate env_logger;
+extern crate gluon;
+
+mod support;
+
+use gluon::Compiler;
+
+#[test]
+fn dont_panic_when_error_span_is_at_eof() {
+    let _ = ::env_logger::init();
+    let vm = support::make_vm();
+    let text = r#"abc"#;
+    let result = Compiler::new().load_script(&vm, "test", text);
+    assert!(result.is_err());
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -14,16 +14,18 @@ pub fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<
 }
 
 pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
-    where T: Getable<'vm> + VmType
+    where T: Getable<'vm> + VmType,
 {
     Compiler::new()
         .implicit_prelude(implicit_prelude)
         .run_expr(vm, "<top>", s)
-        .unwrap_or_else(|err| panic!("{}", err)).0
+        .unwrap_or_else(|err| panic!("{}", err))
+        .0
 }
 
+#[allow(dead_code)]
 pub fn run_expr<'vm, T>(vm: &'vm Thread, s: &str) -> T
-    where T: Getable<'vm> + VmType
+    where T: Getable<'vm> + VmType,
 {
     run_expr_(vm, s, false)
 }
@@ -33,9 +35,9 @@ pub fn make_vm() -> RootedThread {
     let vm = ::gluon::new_vm();
     let import = vm.get_macros().get("import");
     import.as_ref()
-          .and_then(|import| import.downcast_ref::<Import>())
-          .expect("Import macro")
-          .add_path("..");
+        .and_then(|import| import.downcast_ref::<Import>())
+        .expect("Import macro")
+        .add_path("..");
     vm
 }
 


### PR DESCRIPTION
Since spans are exclusive they may refer to indexes one past the end.