### PR TITLE
Fix typo

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -237,7 +237,7 @@ pub struct Offside {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Context {
-    /// Contaxt which contains several expressions/declarations separated by semicolons
+    /// Context which contains several expressions/declarations separated by semicolons
     Block { emit_semi: bool, needs_close: bool },
     /// A simple expression
     Expr,


### PR DESCRIPTION
just fix typo in lexer.rs (`contaxt` -> `context`)