### PR TITLE
chore: Disable skeptic tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
 - |
   sh ./test-no-skeptic.sh &&
   travis-cargo --only nightly test -- --features "test nightly" -p gluon compile_test &&
-  travis-cargo --only stable test -- --features "test skeptic" -p gluon --test skeptic-tests &&
   cargo build --release &&
   travis-cargo --only nightly bench &&
   travis-cargo --only stable doc


### PR DESCRIPTION
Getting failures every single PR now so until skeptic can be made to work on travis I think we need to disable it completely.